### PR TITLE
✅ Add linting and coverage to Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ env:
   - GO111MODULE=on
 go:
   - 1.11.x
+before_script:
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.13.2
 script:
+  - golangci-lint run
   - go test -v -race  -coverprofile=coverage.txt -covermode=atomic ./...
+  - go tool cover -func=coverage.txt | awk '/^total:/ { gsub(/%$/, ""); if ($3 < 100.0) {print "FAIL - Coverage below 100%"; exit(1)} }'
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Fixes #3 
#### Changes proposed in this PR:
- Add [`golangci-lint`](https://github.com/golangci/golangci-lint) version 1.13.2 Travis CI config
- Add `go tool ...` to Travis CI config to fail on coverage <100%