### PR TITLE
🌱 Create Google cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,16 @@
+steps:
+  - id: version
+    name: 'gcr.io/cloud-builders/go'
+    args: ['version']
+    env: ['GOPATH=/workspace/_gopath', 'GO111MODULE=on']
+  - id: test
+    name: 'gcr.io/cloud-builders/go'
+    args: ['test', '-v', '-coverprofile=coverage.out', '-covermode=atomic' , './...']
+    env: ['GOPATH=/workspace/_gopath', 'GO111MODULE=on']
+  - id: cover
+    name: 'gcr.io/cloud-builders/go'
+    env: ['GOPATH=/workspace/_gopath', 'GO111MODULE=on']
+    entrypoint: 'sh'
+    args:
+      - -c 
+      - "{ go tool cover -func=coverage.out | grep -s '^total:.*100.0%'; } || { echo 'FAIL - Coverage below 100%'; exit 1; }"


### PR DESCRIPTION
Fixes #10 

#### Change proposed in this PR:
- Create Google `cloubuild.yaml` according to [specs](https://cloud.google.com/cloud-build/docs/build-config)
  - `go version`
  - `go test ./...`
  -  ensure 100% coverage
- Eventually wire up with CI on Google Cloudbuild:  [`https://console.cloud.google.com/cloud-build/builds?project=gotraining`](https://console.cloud.google.com/cloud-build/builds?project=gotraining)
