### PR TITLE
Lab-4,5 : Numeronyms and stringer interface

### DIFF
--- a/04_numeronym/ShahNikita19/numeronym.go
+++ b/04_numeronym/ShahNikita19/numeronym.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var out io.Writer = os.Stdout
+
+func main() {
+	fmt.Fprint(out, numeronymsFind("accessibility", "Kubernetes", "abc"))
+}
+
+func numeronymsFind(vals ...string) []string {
+	numeronyms := []string{}
+	for _, val := range vals {
+		numeronyms = append(numeronyms, generateNumeronym(val))
+	}
+	return numeronyms
+}
+
+func generateNumeronym(input string) string {
+	inputSize := len(input)
+	if inputSize <= 3 {
+		return input
+	}
+	return fmt.Sprintf("%c%d%c", input[0], inputSize-2, input[inputSize-1])
+}

--- a/04_numeronym/ShahNikita19/numeronym.go
+++ b/04_numeronym/ShahNikita19/numeronym.go
@@ -13,17 +13,19 @@ func main() {
 }
 
 func numeronymsFind(vals ...string) []string {
-	numeronyms := []string{}
-	for _, val := range vals {
-		numeronyms = append(numeronyms, generateNumeronym(val))
+	numeronyms := make([]string, len(vals))
+	for i, val := range vals {
+		numeronyms[i] = generateNumeronym(val)
 	}
 	return numeronyms
 }
 
 func generateNumeronym(input string) string {
-	inputSize := len(input)
-	if inputSize <= 3 {
+	runeRep := []rune(input)
+	inputLen := len(runeRep)
+	//minimum 4 chars are required
+	if inputLen < 4 {
 		return input
 	}
-	return fmt.Sprintf("%c%d%c", input[0], inputSize-2, input[inputSize-1])
+	return fmt.Sprintf("%c%d%c", runeRep[0], inputLen-2, runeRep[inputLen-1])
 }

--- a/04_numeronym/ShahNikita19/numeronym_test.go
+++ b/04_numeronym/ShahNikita19/numeronym_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testMatrix = []struct {
+	input  []string
+	output []string
+}{
+	{[]string{"accessibility", "Kubernetes", "abc"}, []string{"a11y", "K8s", "abc"}},
+	{[]string{"abb a"}, []string{"a3a"}},
+	{[]string{""}, []string{""}}}
+
+func TestNumeronym(t *testing.T) {
+	// Given
+	r := require.New(t)
+	var buf bytes.Buffer
+	out = &buf
+
+	// When
+	main()
+
+	// Then
+	expected := `[a11y K8s abc]`
+	actual := buf.String()
+	r.Equalf(expected, actual, "Unexpected output in main()")
+}
+
+func TestLetters(t *testing.T) {
+	// Given
+	r := require.New(t)
+	for _, testData := range testMatrix {
+		letters := numeronymsFind(testData.input...)
+		r.Equal(letters, testData.output)
+	}
+}

--- a/04_numeronym/ShahNikita19/numeronym_test.go
+++ b/04_numeronym/ShahNikita19/numeronym_test.go
@@ -11,11 +11,17 @@ var testMatrix = []struct {
 	input  []string
 	output []string
 }{
-	{[]string{"accessibility", "Kubernetes", "abc"}, []string{"a11y", "K8s", "abc"}},
+	{[]string{"abba", "accessibility", "Kubernetes", "abc"}, []string{"a2a", "a11y", "K8s", "abc"}},
 	{[]string{"abb a"}, []string{"a3a"}},
-	{[]string{""}, []string{""}}}
+	{[]string{" abb a"}, []string{" 4a"}},
+	{[]string{"   abb a"}, []string{" 6a"}},
+	{[]string{"abb a "}, []string{"a4 "}},
+	{[]string{"abb a   "}, []string{"a6 "}},
+	{[]string{""}, []string{""}},
+	{[]string{"£€€€§‡®"}, []string{"£5®"}},
+	{[]string{"ßäöüÄÖÜ"}, []string{"ß5Ü"}}}
 
-func TestNumeronym(t *testing.T) {
+func TestMainOutput(t *testing.T) {
 	// Given
 	r := require.New(t)
 	var buf bytes.Buffer
@@ -29,12 +35,11 @@ func TestNumeronym(t *testing.T) {
 	actual := buf.String()
 	r.Equalf(expected, actual, "Unexpected output in main()")
 }
-
-func TestLetters(t *testing.T) {
+func TestNumeronyms(t *testing.T) {
 	// Given
 	r := require.New(t)
 	for _, testData := range testMatrix {
-		letters := numeronymsFind(testData.input...)
-		r.Equal(letters, testData.output)
+		numeronymsVal := numeronymsFind(testData.input...)
+		r.Equal(testData.output, numeronymsVal)
 	}
 }

--- a/05_stringer/ShahNikita19/stringer.go
+++ b/05_stringer/ShahNikita19/stringer.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var out io.Writer = os.Stdout
+
+//IPAddr will satisfy stringer
+type IPAddr [4]byte
+
+func (ipAddress IPAddr) String() string {
+	return fmt.Sprintf("%d.%d.%d.%d", ipAddress[0], ipAddress[1], ipAddress[2], ipAddress[3])
+}
+
+func main() {
+	fmt.Fprintln(out, IPAddr{127, 0, 0, 1})
+}

--- a/05_stringer/ShahNikita19/stringer.go
+++ b/05_stringer/ShahNikita19/stringer.go
@@ -11,10 +11,10 @@ var out io.Writer = os.Stdout
 //IPAddr will satisfy stringer
 type IPAddr [4]byte
 
-func (ipAddress IPAddr) String() string {
-	return fmt.Sprintf("%d.%d.%d.%d", ipAddress[0], ipAddress[1], ipAddress[2], ipAddress[3])
+func (ip IPAddr) String() string {
+	return fmt.Sprintf("%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3])
 }
 
 func main() {
-	fmt.Fprintln(out, IPAddr{127, 0, 0, 1})
+	fmt.Fprint(out, IPAddr{12, 23, 23, 24})
 }

--- a/05_stringer/ShahNikita19/stringet_test.go
+++ b/05_stringer/ShahNikita19/stringet_test.go
@@ -2,23 +2,21 @@ package main
 
 import (
 	"bytes"
-	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-var tests = []struct {
-	in  IPAddr
-	out string
+var testMatrix = []struct {
+	input          IPAddr
+	expectedOutput string
 }{
-	{IPAddr{127, 0, 0, 1}, "127.0.0.1"},
-	{IPAddr{}, "0.0.0.0"},
-	{IPAddr{1, 1, 1, 1}, "1.1.1.1"},
+	{IPAddr{255, 123, 39, 40}, "255.123.39.40"},
+	{IPAddr{255, 0, 0, 0}, "255.0.0.0"},
+	{IPAddr{0, 123, 39, 40}, "0.123.39.40"},
 }
 
-func TestIPAddressOutput(t *testing.T) {
+func TestMainOutput(t *testing.T) {
 	// Given
 	r := require.New(t)
 	var buf bytes.Buffer
@@ -28,21 +26,16 @@ func TestIPAddressOutput(t *testing.T) {
 	main()
 
 	// Then
-	expected := strconv.Quote("127.0.0.1\n")
-	actual := strconv.Quote(buf.String())
+	expected := `12.23.23.24`
+	actual := buf.String()
 	r.Equalf(expected, actual, "Unexpected output in main()")
 }
 
-func TestStringOutput(t *testing.T) {
+func TestStringer(t *testing.T) {
+	// Given
 	r := require.New(t)
-	var buf bytes.Buffer
-	out = &buf
 
-	for _, tt := range tests {
-		buf.Reset()
-		fmt.Fprint(out, tt.in)
-		expected := strconv.Quote(tt.out)
-		actual := strconv.Quote(buf.String())
-		r.EqualValues(expected, actual)
+	for _, testData := range testMatrix {
+		r.EqualValues(testData.expectedOutput, testData.input.String())
 	}
 }

--- a/05_stringer/ShahNikita19/stringet_test.go
+++ b/05_stringer/ShahNikita19/stringet_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var tests = []struct {
+	in  IPAddr
+	out string
+}{
+	{IPAddr{127, 0, 0, 1}, "127.0.0.1"},
+	{IPAddr{}, "0.0.0.0"},
+	{IPAddr{1, 1, 1, 1}, "1.1.1.1"},
+}
+
+func TestIPAddressOutput(t *testing.T) {
+	// Given
+	r := require.New(t)
+	var buf bytes.Buffer
+	out = &buf
+
+	// When
+	main()
+
+	// Then
+	expected := strconv.Quote("127.0.0.1\n")
+	actual := strconv.Quote(buf.String())
+	r.Equalf(expected, actual, "Unexpected output in main()")
+}
+
+func TestStringOutput(t *testing.T) {
+	r := require.New(t)
+	var buf bytes.Buffer
+	out = &buf
+
+	for _, tt := range tests {
+		buf.Reset()
+		fmt.Fprint(out, tt.in)
+		expected := strconv.Quote(tt.out)
+		actual := strconv.Quote(buf.String())
+		r.EqualValues(expected, actual)
+	}
+}


### PR DESCRIPTION
Fixes #67

Changes proposed in this PR:
-Program to return numeronyms for a given set of strings
-Test cases for the program

Fixes #70
-Make IPAddr type implement **fmt.Stringer** to print dotted ip address
-Test cases for the program

