### PR TITLE
Lab 4 and 5: Numeronym and Stringers implementation

### DIFF
--- a/04_numeronym/madhavansu/main.go
+++ b/04_numeronym/madhavansu/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 var out io.Writer = os.Stdout
@@ -14,12 +15,12 @@ func main() {
 func numeronyms(vals ...string) []string {
 	var strcopy []string
 	for _, val := range vals {
+		val := []rune(strings.TrimSpace(val))
 		length := len(val)
 		if length > 3 {
-			first, last := val[0:1], val[length-1:]
-			strcopy = append(strcopy, fmt.Sprint(first, length-2, last))
+			strcopy = append(strcopy, fmt.Sprint(string(val[0:1]), length-2, string(val[length-1:])))
 		} else {
-			strcopy = append(strcopy, val)
+			strcopy = append(strcopy, string(val))
 		}
 	}
 	return strcopy

--- a/04_numeronym/madhavansu/main.go
+++ b/04_numeronym/madhavansu/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var out io.Writer = os.Stdout
+
+func main() {
+	fmt.Fprint(out, numeronyms("accessibility", "Kubernetes", "abc"))
+}
+
+func numeronyms(vals ...string) []string {
+	var strcopy []string
+	for _, val := range vals {
+		length := len(val)
+		if length > 3 {
+			first, last := val[0:1], val[length-1:]
+			strcopy = append(strcopy, fmt.Sprint(first, length-2, last))
+		} else {
+			strcopy = append(strcopy, val)
+		}
+
+	}
+	return strcopy
+}

--- a/04_numeronym/madhavansu/main.go
+++ b/04_numeronym/madhavansu/main.go
@@ -13,14 +13,14 @@ func main() {
 	fmt.Fprint(out, numeronyms("accessibility", "Kubernetes", "abc"))
 }
 func numeronyms(vals ...string) []string {
-	var strcopy []string
-	for _, val := range vals {
+	strcopy := make([]string, len(vals))
+	for k, val := range vals {
 		val := []rune(strings.TrimSpace(val))
 		length := len(val)
 		if length > 3 {
-			strcopy = append(strcopy, fmt.Sprint(string(val[0:1]), length-2, string(val[length-1:])))
+			strcopy[k] = fmt.Sprint(string(val[0]), length-2, string(val[length-1]))
 		} else {
-			strcopy = append(strcopy, string(val))
+			strcopy[k] = string(val)
 		}
 	}
 	return strcopy

--- a/04_numeronym/madhavansu/main.go
+++ b/04_numeronym/madhavansu/main.go
@@ -13,15 +13,15 @@ func main() {
 	fmt.Fprint(out, numeronyms("accessibility", "Kubernetes", "abc"))
 }
 func numeronyms(vals ...string) []string {
-	strcopy := make([]string, len(vals))
+	s := make([]string, len(vals))
 	for k, val := range vals {
-		val := []rune(strings.TrimSpace(val))
+		val := []rune(strings.Trim(val, "\n\t\\ "))
 		length := len(val)
 		if length > 3 {
-			strcopy[k] = fmt.Sprint(string(val[0]), length-2, string(val[length-1]))
+			s[k] = fmt.Sprint(string(val[0]), length-2, string(val[length-1]))
 		} else {
-			strcopy[k] = string(val)
+			s[k] = string(val)
 		}
 	}
-	return strcopy
+	return s
 }

--- a/04_numeronym/madhavansu/main.go
+++ b/04_numeronym/madhavansu/main.go
@@ -11,7 +11,6 @@ var out io.Writer = os.Stdout
 func main() {
 	fmt.Fprint(out, numeronyms("accessibility", "Kubernetes", "abc"))
 }
-
 func numeronyms(vals ...string) []string {
 	var strcopy []string
 	for _, val := range vals {
@@ -22,7 +21,6 @@ func numeronyms(vals ...string) []string {
 		} else {
 			strcopy = append(strcopy, val)
 		}
-
 	}
 	return strcopy
 }

--- a/04_numeronym/madhavansu/main.go
+++ b/04_numeronym/madhavansu/main.go
@@ -12,13 +12,14 @@ var out io.Writer = os.Stdout
 func main() {
 	fmt.Fprint(out, numeronyms("accessibility", "Kubernetes", "abc"))
 }
+
 func numeronyms(vals ...string) []string {
 	s := make([]string, len(vals))
 	for k, val := range vals {
 		val := []rune(strings.Trim(val, "\n\t\\ "))
 		length := len(val)
 		if length > 3 {
-			s[k] = fmt.Sprint(string(val[0]), length-2, string(val[length-1]))
+			s[k] = fmt.Sprintf("%c%d%c", val[0], length-2, val[length-1])
 		} else {
 			s[k] = string(val)
 		}

--- a/04_numeronym/madhavansu/main_test.go
+++ b/04_numeronym/madhavansu/main_test.go
@@ -33,7 +33,6 @@ func TestMainOutput(t *testing.T) {
 	actual := strconv.Quote(buf.String())
 	r.Equalf(expected, actual, "Unexpected output in main()")
 }
-
 func TestNumeronyms(t *testing.T) {
 	// Given
 	r := require.New(t)

--- a/04_numeronym/madhavansu/main_test.go
+++ b/04_numeronym/madhavansu/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,10 +12,11 @@ var s = []struct {
 	input  string
 	output string
 }{
-	{"accessibility", "[a11y]"},
+	{"accessibility  ", "[a11y]"},
 	{"Kubernetes", "[K8s]"},
 	{"World Wide Web", "[W12b]"},
-	{"abc", "[abc]"},
+	{"மாதவ", "[ம2வ]"},
+	{"ΩΟΞψωξ", "[Ω4ξ]"},
 }
 
 func TestMainOutput(t *testing.T) {
@@ -29,8 +29,8 @@ func TestMainOutput(t *testing.T) {
 	main()
 
 	// Then
-	expected := strconv.Quote(`[a11y K8s abc]`)
-	actual := strconv.Quote(buf.String())
+	expected := `[a11y K8s abc]`
+	actual := buf.String()
 	r.Equalf(expected, actual, "Unexpected output in main()")
 }
 func TestNumeronyms(t *testing.T) {

--- a/04_numeronym/madhavansu/main_test.go
+++ b/04_numeronym/madhavansu/main_test.go
@@ -2,11 +2,22 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+var s = []struct {
+	input  string
+	output string
+}{
+	{"accessibility", "[a11y]"},
+	{"Kubernetes", "[K8s]"},
+	{"World Wide Web", "[W12b]"},
+	{"abc", "[abc]"},
+}
 
 func TestMainOutput(t *testing.T) {
 	// Given
@@ -21,4 +32,16 @@ func TestMainOutput(t *testing.T) {
 	expected := strconv.Quote(`[a11y K8s abc]`)
 	actual := strconv.Quote(buf.String())
 	r.Equalf(expected, actual, "Unexpected output in main()")
+}
+
+func TestNumeronyms(t *testing.T) {
+	// Given
+	r := require.New(t)
+
+	// When
+	for _, v := range s {
+		expected := fmt.Sprint(numeronyms(v.input))
+		actual := v.output
+		r.Equalf(expected, actual, "Unexpected output in numeronyms()")
+	}
 }

--- a/04_numeronym/madhavansu/main_test.go
+++ b/04_numeronym/madhavansu/main_test.go
@@ -37,6 +37,7 @@ func TestMainOutput(t *testing.T) {
 	// Then
 	r.Equalf(`[a11y K8s abc]`, buf.String(), "Unexpected output in main()")
 }
+
 func TestNumeronyms(t *testing.T) {
 	// Given
 	r := require.New(t)

--- a/04_numeronym/madhavansu/main_test.go
+++ b/04_numeronym/madhavansu/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMainOutput(t *testing.T) {
+	// Given
+	r := require.New(t)
+	var buf bytes.Buffer
+	out = &buf
+
+	// When
+	main()
+
+	// Then
+	expected := strconv.Quote(`[a11y K8s abc]`)
+	actual := strconv.Quote(buf.String())
+	r.Equalf(expected, actual, "Unexpected output in main()")
+}

--- a/04_numeronym/madhavansu/main_test.go
+++ b/04_numeronym/madhavansu/main_test.go
@@ -9,14 +9,20 @@ import (
 )
 
 var s = []struct {
-	input  string
-	output string
+	input    string
+	expected string
 }{
 	{"accessibility  ", "[a11y]"},
 	{"Kubernetes", "[K8s]"},
 	{"World Wide Web", "[W12b]"},
 	{"மாதவ", "[ம2வ]"},
 	{"ΩΟΞψωξ", "[Ω4ξ]"},
+	{"  	   ", "[]"},
+	{"This is a multi word checK", "[T24K]"},
+	{"_This is an underscore and empty char          ", "[_35r]"},
+	{"", "[]"},
+	{"        +        ", "[+]"},
+	{"        \n     \t   ", "[]"},
 }
 
 func TestMainOutput(t *testing.T) {
@@ -29,9 +35,7 @@ func TestMainOutput(t *testing.T) {
 	main()
 
 	// Then
-	expected := `[a11y K8s abc]`
-	actual := buf.String()
-	r.Equalf(expected, actual, "Unexpected output in main()")
+	r.Equalf(`[a11y K8s abc]`, buf.String(), "Unexpected output in main()")
 }
 func TestNumeronyms(t *testing.T) {
 	// Given
@@ -39,8 +43,6 @@ func TestNumeronyms(t *testing.T) {
 
 	// When
 	for _, v := range s {
-		expected := fmt.Sprint(numeronyms(v.input))
-		actual := v.output
-		r.Equalf(expected, actual, "Unexpected output in numeronyms()")
+		r.Equalf(v.expected, fmt.Sprint(numeronyms(v.input)), "Unexpected output in numeronyms()")
 	}
 }

--- a/05_stringer/madhavansu/main.go
+++ b/05_stringer/madhavansu/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var out io.Writer = os.Stdout
+
+type IPAddr [4]byte
+
+func main() {
+	// fmt.Println(iPAddr{127, 0, 0, 1})
+	hosts := map[string]IPAddr{
+		"loopback":  {127, 0, 0, 1},
+		"googleDNS": {8, 8, 8, 8},
+	}
+	for _, ip := range hosts {
+		fmt.Fprint(out, ip)
+	}
+}

--- a/05_stringer/madhavansu/main.go
+++ b/05_stringer/madhavansu/main.go
@@ -15,6 +15,6 @@ func main() {
 	fmt.Fprint(out, IPAddr{127, 0, 0, 1})
 }
 
-func (ipAddr IPAddr) String() string {
-	return fmt.Sprintf("%d.%d.%d.%d", ipAddr[0], ipAddr[1], ipAddr[2], ipAddr[3])
+func (i IPAddr) String() string {
+	return fmt.Sprintf("%d.%d.%d.%d", i[0], i[1], i[2], i[3])
 }

--- a/05_stringer/madhavansu/main.go
+++ b/05_stringer/madhavansu/main.go
@@ -8,15 +8,13 @@ import (
 
 var out io.Writer = os.Stdout
 
+// IPAddr export
 type IPAddr [4]byte
 
 func main() {
-	// fmt.Println(iPAddr{127, 0, 0, 1})
-	hosts := map[string]IPAddr{
-		"loopback":  {127, 0, 0, 1},
-		"googleDNS": {8, 8, 8, 8},
-	}
-	for _, ip := range hosts {
-		fmt.Fprint(out, ip)
-	}
+	fmt.Fprint(out, IPAddr{127, 0, 0, 1})
+}
+
+func (ipAddr IPAddr) String() string {
+	return fmt.Sprintf("%d.%d.%d.%d", ipAddr[0], ipAddr[1], ipAddr[2], ipAddr[3])
 }

--- a/05_stringer/madhavansu/main_test.go
+++ b/05_stringer/madhavansu/main_test.go
@@ -18,14 +18,12 @@ func TestMainOutput(t *testing.T) {
 	main()
 
 	// Then
-	expected := `127.0.0.1`
-	actual := buf.String()
-	r.Equalf(expected, actual, "Unexpected output in main()")
+	r.Equalf(`127.0.0.1`, buf.String(), "Unexpected output in main()")
 }
 
 var s = []struct {
-	input  IPAddr
-	output string
+	input    IPAddr
+	expected string
 }{
 
 	{IPAddr{127, 0, 0, 1}, "127.0.0.1"},
@@ -42,8 +40,6 @@ func TestIPAddrInterface(t *testing.T) {
 
 	// When
 	for _, v := range s {
-		expected := fmt.Sprint(v.input)
-		actual := v.output
-		r.Equalf(expected, actual, "Unexpected output in IPAddr()")
+		r.Equalf(v.expected, fmt.Sprint(v.input), "Unexpected output in IPAddr()")
 	}
 }

--- a/05_stringer/madhavansu/main_test.go
+++ b/05_stringer/madhavansu/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,8 +18,8 @@ func TestMainOutput(t *testing.T) {
 	main()
 
 	// Then
-	expected := strconv.Quote(`127.0.0.1`)
-	actual := strconv.Quote(buf.String())
+	expected := `127.0.0.1`
+	actual := buf.String()
 	r.Equalf(expected, actual, "Unexpected output in main()")
 }
 
@@ -28,9 +27,13 @@ var s = []struct {
 	input  IPAddr
 	output string
 }{
+
 	{IPAddr{127, 0, 0, 1}, "127.0.0.1"},
 	{IPAddr{10, 10, 40, 1}, "10.10.40.1"},
-	{IPAddr{7, 20, 210, 12}, "7.20.210.12"},
+	{IPAddr{7, 20, 210}, "7.20.210.0"},
+	{IPAddr{7, 20}, "7.20.0.0"},
+	{IPAddr{0}, "0.0.0.0"},
+	{IPAddr{}, "0.0.0.0"},
 }
 
 func TestIPAddrInterface(t *testing.T) {

--- a/05_stringer/madhavansu/main_test.go
+++ b/05_stringer/madhavansu/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -21,4 +22,25 @@ func TestMainOutput(t *testing.T) {
 	expected := strconv.Quote(`127.0.0.1`)
 	actual := strconv.Quote(buf.String())
 	r.Equalf(expected, actual, "Unexpected output in main()")
+}
+
+var s = []struct {
+	input  IPAddr
+	output string
+}{
+	{IPAddr{127, 0, 0, 1}, "127.0.0.1"},
+	{IPAddr{10, 10, 40, 1}, "10.10.40.1"},
+	{IPAddr{7, 20, 210, 12}, "7.20.210.12"},
+}
+
+func TestIPAddrInterface(t *testing.T) {
+	// Given
+	r := require.New(t)
+
+	// When
+	for _, v := range s {
+		expected := fmt.Sprint(v.input)
+		actual := v.output
+		r.Equalf(expected, actual, "Unexpected output in IPAddr()")
+	}
 }

--- a/05_stringer/madhavansu/main_test.go
+++ b/05_stringer/madhavansu/main_test.go
@@ -18,7 +18,7 @@ func TestMainOutput(t *testing.T) {
 	main()
 
 	// Then
-	expected := strconv.Quote(`[127 0 0 1][8 8 8 8]`)
+	expected := strconv.Quote(`127.0.0.1`)
 	actual := strconv.Quote(buf.String())
 	r.Equalf(expected, actual, "Unexpected output in main()")
 }

--- a/05_stringer/madhavansu/main_test.go
+++ b/05_stringer/madhavansu/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMainOutput(t *testing.T) {
+	// Given
+	r := require.New(t)
+	var buf bytes.Buffer
+	out = &buf
+
+	// When
+	main()
+
+	// Then
+	expected := strconv.Quote(`[127 0 0 1][8 8 8 8]`)
+	actual := strconv.Quote(buf.String())
+	r.Equalf(expected, actual, "Unexpected output in main()")
+}


### PR DESCRIPTION
Fixes #67, fixes #70  

#### Changes proposed in this PR:

- Write a function that returns a slice of numeronyms for its input strings
- Make the IPAddr type implement fmt.Stringer to print the address as a dotted quad
