### PR TITLE
Lab 4 and 5 - Numeronyms and Stringer

### DIFF
--- a/04_numeronym/satish/main.go
+++ b/04_numeronym/satish/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+)
+
+var out io.Writer = os.Stdout
+
+func numeronyms(vals ...string) []string {
+	// make a copy of input
+	cpy := make([]string, len(vals))
+	for i := 0; i < len(vals); i++ {
+		strLen := len(vals[i])
+		if strLen < 4 {
+			cpy[i] = vals[i]
+		} else {
+			firstChar := string(vals[i][0])
+			lastChar := string(vals[i][strLen-1])
+			remainingChars := strconv.Itoa(strLen - 2)
+			shortForm := firstChar + remainingChars + lastChar
+			cpy[i] = shortForm
+		}
+	}
+	return cpy
+}
+
+func main() {
+	vals := []string{"accessibility", "Kubernetes", "abc"}
+	fmt.Fprint(out, numeronyms(vals...))
+}

--- a/04_numeronym/satish/main_test.go
+++ b/04_numeronym/satish/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMainOutput(t *testing.T) {
+	// Given
+	r := require.New(t)
+	var buf bytes.Buffer
+	out = &buf
+
+	// When
+	main()
+
+	// Then
+	expected := "[a11y K8s abc]"
+	actual := buf.String()
+	r.Equalf(expected, actual, "Unexpected output in main()")
+}
+
+var tests = []struct {
+	in  []string
+	out []string
+}{
+	{[]string{"internationalization", "Administration", "Africanization", "Appocalypse"}, []string{"i18n", "A12n",
+		"A12n", "A9e"}},
+	{[]string{}, []string{}},
+}
+
+func TestNumeronymsWithValues(t *testing.T) {
+	r := require.New(t)
+
+	for _, tt := range tests {
+		out := numeronyms(tt.in...)
+		r.EqualValues(tt.out, out)
+	}
+}

--- a/05_stringer/satish/main.go
+++ b/05_stringer/satish/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var out io.Writer = os.Stdout
+
+type IPAddr [4]byte
+
+func (ip IPAddr) String() string {
+	return fmt.Sprintf("%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3])
+}
+
+func main() {
+	fmt.Fprintln(out, IPAddr{127, 0, 0, 1})
+}

--- a/05_stringer/satish/main_test.go
+++ b/05_stringer/satish/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMainOutput(t *testing.T) {
+	// Given
+	r := require.New(t)
+	var buf bytes.Buffer
+	out = &buf
+
+	// When
+	main()
+
+	// Then
+	expected := "127.0.0.1\n"
+	actual := buf.String()
+	r.Equalf(expected, actual, "Unexpected output in main()")
+}
+
+// var tests = []struct {
+// 	in  []string
+// 	out []string
+// }{
+// 	{[]string{"internationalization", "Administration", "Africanization", "Appocalypse"}, []string{"i18n", "A12n",
+// 		"A12n", "A9e"}},
+// 	{[]string{}, []string{}},
+// }
+
+// func TestNumeronymsWithValues(t *testing.T) {
+// 	r := require.New(t)
+
+// 	for _, tt := range tests {
+// 		out := numeronyms(tt.in...)
+// 		r.EqualValues(tt.out, out)
+// 	}
+// }


### PR DESCRIPTION
Fixes #67, fixes #70 

#### Changes proposed in this PR:
- Implement numeronyms
- Make the IPAddr type implement fmt.Stringer to print the address as a dotted quad
