### PR TITLE
05 stringer

### DIFF
--- a/05_stringer/sahidakhtar1/main.go
+++ b/05_stringer/sahidakhtar1/main.go
@@ -8,9 +8,7 @@ import (
 
 var out io.Writer = os.Stdout
 
-type MyByte byte
-
-type IPAddr [4]MyByte
+type IPAddr [4]byte
 
 func (i IPAddr) String() string {
 	return fmt.Sprintf("%d.%d.%d.%d", i[0], i[1], i[2], i[3])

--- a/05_stringer/sahidakhtar1/main.go
+++ b/05_stringer/sahidakhtar1/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var out io.Writer = os.Stdout
+
+type IPAddr [4]byte
+
+func (i IPAddr) String() string {
+	return fmt.Sprintf("%v.%v.%v.%v", i[0], i[1], i[2], i[3])
+}
+
+func main() {
+	fmt.Fprintln(out, IPAddr{127, 0, 0, 1})
+}

--- a/05_stringer/sahidakhtar1/main.go
+++ b/05_stringer/sahidakhtar1/main.go
@@ -8,10 +8,12 @@ import (
 
 var out io.Writer = os.Stdout
 
-type IPAddr [4]byte
+type MyByte byte
+
+type IPAddr [4]MyByte
 
 func (i IPAddr) String() string {
-	return fmt.Sprintf("%v.%v.%v.%v", i[0], i[1], i[2], i[3])
+	return fmt.Sprintf("%d.%d.%d.%d", i[0], i[1], i[2], i[3])
 }
 
 func main() {

--- a/05_stringer/sahidakhtar1/main_test.go
+++ b/05_stringer/sahidakhtar1/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(t *testing.T) {
+	//Given
+	r := require.New(t)
+	var buf bytes.Buffer
+	out = &buf
+
+	// When
+	main()
+
+	// Then
+	expected := "127.0.0.1\n"
+	actual := buf.String()
+	r.Equalf(expected, actual, "Unexpected output in main()")
+}
+
+var testData = []struct {
+	in  IPAddr
+	out string
+}{
+	{IPAddr{127, 0, 0, 1}, "127.0.0.1"},
+	{IPAddr{0, 0, 0, 0}, "0.0.0.0"},
+	{IPAddr{255, 255, 255, 255}, "255.255.255.255"},
+	{IPAddr{1}, "1.0.0.0"},
+}
+
+func TestIPAddrFmtInterfaceImpl(t *testing.T) {
+	r := require.New(t)
+	for _, tt := range testData {
+		r.Equalf(tt.out, tt.in.String(), "Convert IP address to dotted quad fails")
+	}
+}


### PR DESCRIPTION
Fixes #70 

#### Changes proposed in this PR:

* Created type `IPAddr` to capture all 4 components of an IP address .
* Implemented `Stringer` interface to print the IP address in dotted quad.
