### PR TITLE
Improve lab README code blocks

### DIFF
--- a/01_fib/README.md
+++ b/01_fib/README.md
@@ -1,6 +1,6 @@
 # Lab 1 - Fibonacci
 
-Create an executable go program in directory 01_fib/USERNAME
+Create an executable go program in directory `01_fib/USERNAME`
 Write a function that prints the first n Fibonacci numbers
 
 ```

--- a/02_bubble/README.md
+++ b/02_bubble/README.md
@@ -7,7 +7,7 @@ Write a function that returns a sorted copy of `int` slice `s` using [bubble sor
 func bubble(s []int) []int
 ```
 
-Call `fmt.Println(bubble([]int{3,` `2,` `1,` `5}))` in `main` to print:
+Call `fmt.Println(bubble([]int{3, 2, 1, 5}))` in `main` to print:
 
 ```
 [1 2 3 5]

--- a/03_letters/README.md
+++ b/03_letters/README.md
@@ -13,7 +13,7 @@ Write a function that returns a sorted slice of strings with elements  `"{key}:{
 func sortLetters(m map[rune]int) []string
 ```
 
-Call `fmt.Println(strings.Join(sortLetters(letters("aba"))),` `"\n")` in `main` to print:
+Call `fmt.Println(strings.Join(sortLetters(letters("aba"))), "\n")` in `main` to print:
 
 ```
 a:2

--- a/04_numeronym/README.md
+++ b/04_numeronym/README.md
@@ -7,7 +7,7 @@ Write a function that returns a slice of numeronyms for its input strings:
 func numeronyms(vals ...string) []string
 ```
 
-Call `fmt.Println(numeronyms("accessibility",` `"Kubernetes",` `"abc"))` in `main` to print:
+Call `fmt.Println(numeronyms("accessibility", "Kubernetes", "abc"))` in `main` to print:
 
 ```
 [a11y K8s abc]

--- a/05_stringer/README.md
+++ b/05_stringer/README.md
@@ -3,7 +3,7 @@
 Create an executable go program in directory `05_stringer/USERNAME`
 Make the `IPAddr` type implement `fmt.Stringer` to print the address as a dotted quad
 Find hints at [tour of go exercise: stringers](https://tour.golang.org/methods/18)
-Call `fmt.Println(IPAddr{127,` `0,` `0,` `1})` in `main` to print:
+Call `fmt.Println(IPAddr{127, 0, 0, 1})` in `main` to print:
 
 ```
 127.0.0.1

--- a/09_json/README.md
+++ b/09_json/README.md
@@ -3,5 +3,5 @@
 Create directory `09_json/USERNAME` containing a copy of upstream master `08_project/USERNAME`
 Add JSON tags to puppy data type
 Test marshalling and unmarshalling using [require.jsoneq](https://godoc.org/github.com/stretchr/testify/require#JSONEq)
-Add command line flag `-d` `FILE` with long form `--data` `FILE` using [kingpin.v2](https://godoc.org/gopkg.in/alecthomas/kingpin.v2)
+Add command line flag `-d FILE` with long form `--data FILE` using [kingpin.v2](https://godoc.org/gopkg.in/alecthomas/kingpin.v2)
 FILE should contain an array of puppies in JSON format. Parse this file and store its contents.

--- a/10_rest/README.md
+++ b/10_rest/README.md
@@ -11,8 +11,8 @@ DELETE /api/puppy/{id}
 ```
 
 Use [net/http/httptest](https://golang.org/pkg/net/http/httptest/) for testing
-Add flag `-p` `PORT` with long flag `--port` `PORT` to command line flags
-Add flag `-s` `STORE` with long flag `--store` `STORE` with accepted values:
+Add flag `-p PORT` with long flag `--port PORT` to command line flags
+Add flag `-s STORE` with long flag `--store STORE` with accepted values:
 
 ```
 map, sync, db


### PR DESCRIPTION
So I actually had a look at the README's in github and some of the code blocks were broken up due to the extra back-ticks from the slides. Didn't notice it in an editor.

Also added back-ticks around lab1 directory for consistency.