### PR TITLE
Remove testify from hello world test

### DIFF
--- a/00_hello_world/juliaogris/main_test.go
+++ b/00_hello_world/juliaogris/main_test.go
@@ -4,21 +4,18 @@ import (
 	"bytes"
 	"strconv"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestMainOutput(t *testing.T) {
-	// Given
-	r := require.New(t)
 	var buf bytes.Buffer
 	out = &buf
 
-	// When
 	main()
 
-	// Then
 	expected := strconv.Quote("Hallo du schöne Welt!\n")
 	actual := strconv.Quote(buf.String())
-	r.Equalf(expected, actual, "Unexpected output in main()")
+
+	if expected != actual {
+		t.Errorf("Unexpected output in main()")
+	}
 }


### PR DESCRIPTION
This encourages people to start by using the testing.T object
directly and gain a better understanding of how testing works in go
before moving to richer test libraries.
