### PR TITLE
Fix formatting for lab README files

### DIFF
--- a/01_fib/README.md
+++ b/01_fib/README.md
@@ -1,13 +1,13 @@
 # Lab 1 - Fibonacci
 
-Create an executable go program in directory `01_fib/USERNAME`
-Write a function that prints the first n Fibonacci numbers
+- Create an executable go program in directory `01_fib/USERNAME`
+- Write a function that prints the first n Fibonacci numbers
 
 ```
 func fib(n int)
 ```
 
-Call fib(7) in main to print
+Call `fib(7)` in `main` to print
 
 ```
 1

--- a/02_bubble/README.md
+++ b/02_bubble/README.md
@@ -1,7 +1,7 @@
 # Lab 2 - Bubble sort
 
-Create an executable go program in directory `02_bubble/USERNAME`
-Write a function that returns a sorted copy of `int` slice `s` using [bubble sort](https://en.wikipedia.org/wiki/Bubble_sort):
+- Create an executable go program in directory `02_bubble/USERNAME`
+- Write a function that returns a sorted copy of `int` slice `s` using [bubble sort](https://en.wikipedia.org/wiki/Bubble_sort):
 
 ```
 func bubble(s []int) []int
@@ -13,5 +13,5 @@ Call `fmt.Println(bubble([]int{3, 2, 1, 5}))` in `main` to print:
 [1 2 3 5]
 ```
 
-Bonus points: implement [Insertion sort](https://en.wikipedia.org/wiki/Insertion_sort)
-Extra bonus points: implement an _O(n_ _log(n))_ sorting algorithm
+- Bonus points: implement [Insertion sort](https://en.wikipedia.org/wiki/Insertion_sort)
+- Extra bonus points: implement an _O(n_ _log(n))_ sorting algorithm

--- a/03_letters/README.md
+++ b/03_letters/README.md
@@ -1,13 +1,13 @@
 # Lab 3 - Letter frequency
 
-Create an executable go program in directory `03_letters/USERNAME`
-Write a function that returns a mapping of each letter to its frequency:
+- Create an executable go program in directory `03_letters/USERNAME`
+- Write a function that returns a mapping of each letter to its frequency:
 
 ```
 func letters(s string) map[rune]int
 ```
 
-Write a function that returns a sorted slice of strings with elements  `"{key}:{val}"`. Use package [sort](https://golang.org/pkg/sort/):
+Write a function that returns a sorted slice of strings with elements `"{key}:{val}"`. Use package [sort](https://golang.org/pkg/sort/):
 
 ```
 func sortLetters(m map[rune]int) []string

--- a/04_numeronym/README.md
+++ b/04_numeronym/README.md
@@ -1,7 +1,7 @@
 # Lab 4 - Numeronym
 
-Create an executable go program in directory `04_numeronym/USERNAME`
-Write a function that returns a slice of numeronyms for its input strings:
+- Create an executable go program in directory `04_numeronym/USERNAME`
+- Write a function that returns a slice of numeronyms for its input strings:
 
 ```
 func numeronyms(vals ...string) []string

--- a/05_stringer/README.md
+++ b/05_stringer/README.md
@@ -1,9 +1,9 @@
 # Lab 5 - Stringer
 
-Create an executable go program in directory `05_stringer/USERNAME`
-Make the `IPAddr` type implement `fmt.Stringer` to print the address as a dotted quad
-Find hints at [tour of go exercise: stringers](https://tour.golang.org/methods/18)
-Call `fmt.Println(IPAddr{127, 0, 0, 1})` in `main` to print:
+- Create an executable go program in directory `05_stringer/USERNAME`
+- Make the `IPAddr` type implement `fmt.Stringer` to print the address as a dotted quad
+- Find hints at [tour of go exercise: stringers](https://tour.golang.org/methods/18)
+- Call `fmt.Println(IPAddr{127, 0, 0, 1})` in `main` to print:
 
 ```
 127.0.0.1

--- a/06_puppy/README.md
+++ b/06_puppy/README.md
@@ -1,9 +1,9 @@
 # Lab 6 - CRUD puppy with interface
 
-Create an executable go program in directory `06_puppy/USERNAME` (see [hints]([https://github.com/anz-bank/go-samplerest/blob/master/pkg/pet/types.go))
-Implement a `Puppy` struct containing `ID`, `Breed`, `Colour`, `Value`
-Create `Storer` interface with [crud](https://en.wikipedia.org/wiki/Create,\_read,\_update_and_delete) methods for `Puppy`
-Write a `MapStore` implementation of `Storer` backed by a `map`
-Write a `SyncStore` implementation of `Storer` backed by a [sync.map](https://golang.org/pkg/sync/#Map)
-Keep all implementation files in the same folder and in package `main`
-Test against the `Storer` interface and run in [suite](https://godoc.org/github.com/stretchr/testify/suite) with both implementations
+- Create an executable go program in directory `06_puppy/USERNAME` (see [hints](https://github.com/anz-bank/go-samplerest/blob/master/pkg/pet/types.go))
+- Implement a `Puppy` struct containing `ID`, `Breed`, `Colour`, `Value`
+- Create `Storer` interface with [crud](https://en.wikipedia.org/wiki/Create,\_read,\_update_and_delete) methods for `Puppy`
+- Write a `MapStore` implementation of `Storer` backed by a `map`
+- Write a `SyncStore` implementation of `Storer` backed by a [sync.Map](https://golang.org/pkg/sync/#Map)
+- Keep all implementation files in the same folder and in package `main`
+- Test against the `Storer` interface and run in [suite](https://godoc.org/github.com/stretchr/testify/suite) with both implementations

--- a/07_errors/README.md
+++ b/07_errors/README.md
@@ -1,13 +1,13 @@
 # Lab 7 - Errors
 
-Create an executable go program in directory `07_errors/USERNAME`
-Copy the CRUD puppy from upstream master `06_puppy/USERNAME`
-Add a custom error type `Error` with fields `Message` and `Code`
-Extend the `Storer` interface for all methods to also return `error`
-Create errors for:
+- Create an executable go program in directory `07_errors/USERNAME`
+- Copy the CRUD puppy from upstream master `06_puppy/USERNAME`
+- Add a custom error type `Error` with fields `Message` and `Code`
+- Extend the `Storer` interface for all methods to also return `error`
+- Create errors for:
 
         - Value < 0
         - ID not found in Read, Update and Delete
 
-Add locking for proper use of sync.Map
-Bonus points: Add a third `Storer` implementation using [leveldb](https://github.com/syndtr/goleveldb)
+- Add locking for proper use of sync.Map
+- Bonus points: Add a third `Storer` implementation using [leveldb](https://github.com/syndtr/goleveldb)

--- a/08_project/README.md
+++ b/08_project/README.md
@@ -1,7 +1,7 @@
 # Lab 8 - Project Layout
 
-Copy the CRUD puppy from upstream master `07_errors/USERNAME`
-Create directory `08_project/USERNAME` containing
+- Copy the CRUD puppy from upstream master `07_errors/USERNAME`
+- Create directory `08_project/USERNAME` containing
 
 ```
 ├── README.md

--- a/09_json/README.md
+++ b/09_json/README.md
@@ -1,7 +1,7 @@
 # Lab 9 - JSON puppy
 
-Create directory `09_json/USERNAME` containing a copy of upstream master `08_project/USERNAME`
-Add JSON tags to puppy data type
-Test marshalling and unmarshalling using [require.jsoneq](https://godoc.org/github.com/stretchr/testify/require#JSONEq)
-Add command line flag `-d FILE` with long form `--data FILE` using [kingpin.v2](https://godoc.org/gopkg.in/alecthomas/kingpin.v2)
-FILE should contain an array of puppies in JSON format. Parse this file and store its contents.
+- Create directory `09_json/USERNAME` containing a copy of upstream master `08_project/USERNAME`
+- Add JSON tags to puppy data type
+- Test marshalling and unmarshalling using [require.JSONEq](https://godoc.org/github.com/stretchr/testify/require#JSONEq)
+- Add command line flag `-d FILE` with long form `--data FILE` using [kingpin.v2](https://godoc.org/gopkg.in/alecthomas/kingpin.v2)
+- FILE should contain an array of puppies in JSON format. Parse this file and store its contents.

--- a/10_rest/README.md
+++ b/10_rest/README.md
@@ -1,7 +1,7 @@
 # Lab 10 - Puppy REST
 
-Create directory `10_rest/USERNAME` containing a copy of upstream master `09_json/USERNAME`
-Add file `pkg/puppy/rest.go` implementing:
+- Create directory `10_rest/USERNAME` containing a copy of upstream master `09_json/USERNAME`
+- Add file `pkg/puppy/rest.go` implementing:
 
 ```
 GET    /api/puppy/{id}
@@ -10,9 +10,9 @@ PUT    /api/puppy/{id}      Payload: Puppy JSON without ID
 DELETE /api/puppy/{id}
 ```
 
-Use [net/http/httptest](https://golang.org/pkg/net/http/httptest/) for testing
-Add flag `-p PORT` with long flag `--port PORT` to command line flags
-Add flag `-s STORE` with long flag `--store STORE` with accepted values:
+- Use [net/http/httptest](https://golang.org/pkg/net/http/httptest/) for testing
+- Add flag `-p PORT` with long flag `--port PORT` to command line flags
+- Add flag `-s STORE` with long flag `--store STORE` with accepted values:
 
 ```
 map, sync, db

--- a/11_notify/README.md
+++ b/11_notify/README.md
@@ -1,7 +1,7 @@
 # Lab 11 - Puppy Notifications
 
-Create directory `11_notify/USERNAME` containing a copy of upstream master `10_rest/USERNAME`
-Create `cmd/lostpuppy-service/main.go` running single endpoint:
+- Create directory `11_notify/USERNAME` containing a copy of upstream master `10_rest/USERNAME`
+- Create `cmd/lostpuppy-service/main.go` running single endpoint:
 ```
 POST   /api/lostpuppy/          Payload: { id: PUPPY_ID }
 This stubbed endpoint returns with 2 second delay:

--- a/labs.md
+++ b/labs.md
@@ -1,13 +1,13 @@
 # Lab 1 - Fibonacci
 
-Create an executable go program in directory `01_fib/USERNAME`
-Write a function that prints the first n Fibonacci numbers
+- Create an executable go program in directory `01_fib/USERNAME`
+- Write a function that prints the first n Fibonacci numbers
 
 ```
 func fib(n int)
 ```
 
-Call fib(7) in main to print
+Call `fib(7)` in `main` to print
 
 ```
 1
@@ -23,8 +23,8 @@ Bonus points: For negative n print Negafibonacci numbers.
 
 # Lab 2 - Bubble sort
 
-Create an executable go program in directory `02_bubble/USERNAME`
-Write a function that returns a sorted copy of `int` slice `s` using [bubble sort](https://en.wikipedia.org/wiki/Bubble_sort):
+- Create an executable go program in directory `02_bubble/USERNAME`
+- Write a function that returns a sorted copy of `int` slice `s` using [bubble sort](https://en.wikipedia.org/wiki/Bubble_sort):
 
 ```
 func bubble(s []int) []int
@@ -36,19 +36,19 @@ Call `fmt.Println(bubble([]int{3, 2, 1, 5}))` in `main` to print:
 [1 2 3 5]
 ```
 
-Bonus points: implement [Insertion sort](https://en.wikipedia.org/wiki/Insertion_sort)
-Extra bonus points: implement an _O(n_ _log(n))_ sorting algorithm
+- Bonus points: implement [Insertion sort](https://en.wikipedia.org/wiki/Insertion_sort)
+- Extra bonus points: implement an _O(n_ _log(n))_ sorting algorithm
 
 # Lab 3 - Letter frequency
 
-Create an executable go program in directory `03_letters/USERNAME`
-Write a function that returns a mapping of each letter to its frequency:
+- Create an executable go program in directory `03_letters/USERNAME`
+- Write a function that returns a mapping of each letter to its frequency:
 
 ```
 func letters(s string) map[rune]int
 ```
 
-Write a function that returns a sorted slice of strings with elements  `"{key}:{val}"`. Use package [sort](https://golang.org/pkg/sort/):
+Write a function that returns a sorted slice of strings with elements `"{key}:{val}"`. Use package [sort](https://golang.org/pkg/sort/):
 
 ```
 func sortLetters(m map[rune]int) []string
@@ -65,8 +65,8 @@ Bonus points: comprehensive tests
 
 # Lab 4 - Numeronym
 
-Create an executable go program in directory `04_numeronym/USERNAME`
-Write a function that returns a slice of numeronyms for its input strings:
+- Create an executable go program in directory `04_numeronym/USERNAME`
+- Write a function that returns a slice of numeronyms for its input strings:
 
 ```
 func numeronyms(vals ...string) []string
@@ -80,10 +80,10 @@ Call `fmt.Println(numeronyms("accessibility", "Kubernetes", "abc"))` in `main` t
 
 # Lab 5 - Stringer
 
-Create an executable go program in directory `05_stringer/USERNAME`
-Make the `IPAddr` type implement `fmt.Stringer` to print the address as a dotted quad
-Find hints at [tour of go exercise: stringers](https://tour.golang.org/methods/18)
-Call `fmt.Println(IPAddr{127, 0, 0, 1})` in `main` to print:
+- Create an executable go program in directory `05_stringer/USERNAME`
+- Make the `IPAddr` type implement `fmt.Stringer` to print the address as a dotted quad
+- Find hints at [tour of go exercise: stringers](https://tour.golang.org/methods/18)
+- Call `fmt.Println(IPAddr{127, 0, 0, 1})` in `main` to print:
 
 ```
 127.0.0.1
@@ -91,32 +91,32 @@ Call `fmt.Println(IPAddr{127, 0, 0, 1})` in `main` to print:
 
 # Lab 6 - CRUD puppy with interface
 
-Create an executable go program in directory `06_puppy/USERNAME` (see [hints]([https://github.com/anz-bank/go-samplerest/blob/master/pkg/pet/types.go))
-Implement a `Puppy` struct containing `ID`, `Breed`, `Colour`, `Value`
-Create `Storer` interface with [crud](https://en.wikipedia.org/wiki/Create,\_read,\_update_and_delete) methods for `Puppy`
-Write a `MapStore` implementation of `Storer` backed by a `map`
-Write a `SyncStore` implementation of `Storer` backed by a [sync.map](https://golang.org/pkg/sync/#Map)
-Keep all implementation files in the same folder and in package `main`
-Test against the `Storer` interface and run in [suite](https://godoc.org/github.com/stretchr/testify/suite) with both implementations
+- Create an executable go program in directory `06_puppy/USERNAME` (see [hints](https://github.com/anz-bank/go-samplerest/blob/master/pkg/pet/types.go))
+- Implement a `Puppy` struct containing `ID`, `Breed`, `Colour`, `Value`
+- Create `Storer` interface with [crud](https://en.wikipedia.org/wiki/Create,\_read,\_update_and_delete) methods for `Puppy`
+- Write a `MapStore` implementation of `Storer` backed by a `map`
+- Write a `SyncStore` implementation of `Storer` backed by a [sync.Map](https://golang.org/pkg/sync/#Map)
+- Keep all implementation files in the same folder and in package `main`
+- Test against the `Storer` interface and run in [suite](https://godoc.org/github.com/stretchr/testify/suite) with both implementations
 
 # Lab 7 - Errors
 
-Create an executable go program in directory `07_errors/USERNAME`
-Copy the CRUD puppy from upstream master `06_puppy/USERNAME`
-Add a custom error type `Error` with fields `Message` and `Code`
-Extend the `Storer` interface for all methods to also return `error`
-Create errors for:
+- Create an executable go program in directory `07_errors/USERNAME`
+- Copy the CRUD puppy from upstream master `06_puppy/USERNAME`
+- Add a custom error type `Error` with fields `Message` and `Code`
+- Extend the `Storer` interface for all methods to also return `error`
+- Create errors for:
 
         - Value < 0
         - ID not found in Read, Update and Delete
 
-Add locking for proper use of sync.Map
-Bonus points: Add a third `Storer` implementation using [leveldb](https://github.com/syndtr/goleveldb)
+- Add locking for proper use of sync.Map
+- Bonus points: Add a third `Storer` implementation using [leveldb](https://github.com/syndtr/goleveldb)
 
 # Lab 8 - Project Layout
 
-Copy the CRUD puppy from upstream master `07_errors/USERNAME`
-Create directory `08_project/USERNAME` containing
+- Copy the CRUD puppy from upstream master `07_errors/USERNAME`
+- Create directory `08_project/USERNAME` containing
 
 ```
 ├── README.md
@@ -141,16 +141,16 @@ Add project introduction and how to build, run & test it to `README.md`
 
 # Lab 9 - JSON puppy
 
-Create directory `09_json/USERNAME` containing a copy of upstream master `08_project/USERNAME`
-Add JSON tags to puppy data type
-Test marshalling and unmarshalling using [require.jsoneq](https://godoc.org/github.com/stretchr/testify/require#JSONEq)
-Add command line flag `-d FILE` with long form `--data FILE` using [kingpin.v2](https://godoc.org/gopkg.in/alecthomas/kingpin.v2)
-FILE should contain an array of puppies in JSON format. Parse this file and store its contents.
+- Create directory `09_json/USERNAME` containing a copy of upstream master `08_project/USERNAME`
+- Add JSON tags to puppy data type
+- Test marshalling and unmarshalling using [require.JSONEq](https://godoc.org/github.com/stretchr/testify/require#JSONEq)
+- Add command line flag `-d FILE` with long form `--data FILE` using [kingpin.v2](https://godoc.org/gopkg.in/alecthomas/kingpin.v2)
+- FILE should contain an array of puppies in JSON format. Parse this file and store its contents.
 
 # Lab 10 - Puppy REST
 
-Create directory `10_rest/USERNAME` containing a copy of upstream master `09_json/USERNAME`
-Add file `pkg/puppy/rest.go` implementing:
+- Create directory `10_rest/USERNAME` containing a copy of upstream master `09_json/USERNAME`
+- Add file `pkg/puppy/rest.go` implementing:
 
 ```
 GET    /api/puppy/{id}
@@ -159,9 +159,9 @@ PUT    /api/puppy/{id}      Payload: Puppy JSON without ID
 DELETE /api/puppy/{id}
 ```
 
-Use [net/http/httptest](https://golang.org/pkg/net/http/httptest/) for testing
-Add flag `-p PORT` with long flag `--port PORT` to command line flags
-Add flag `-s STORE` with long flag `--store STORE` with accepted values:
+- Use [net/http/httptest](https://golang.org/pkg/net/http/httptest/) for testing
+- Add flag `-p PORT` with long flag `--port PORT` to command line flags
+- Add flag `-s STORE` with long flag `--store STORE` with accepted values:
 
 ```
 map, sync, db
@@ -170,8 +170,8 @@ Document the API in README.md
 
 # Lab 11 - Puppy Notifications
 
-Create directory `11_notify/USERNAME` containing a copy of upstream master `10_rest/USERNAME`
-Create `cmd/lostpuppy-service/main.go` running single endpoint:
+- Create directory `11_notify/USERNAME` containing a copy of upstream master `10_rest/USERNAME`
+- Create `cmd/lostpuppy-service/main.go` running single endpoint:
 ```
 POST   /api/lostpuppy/          Payload: { id: PUPPY_ID }
 This stubbed endpoint returns with 2 second delay:
@@ -179,3 +179,4 @@ HTTP status 201 for even IDs
 HTTP status 500 for odd IDs
 ```
 Update Puppy Delete method to notify lostpuppy-service in a goroutine and log response code asynchronously.
+


### PR DESCRIPTION
A lot of the lab exercises are written with dot points, but GitHub's Markdown
engine unwraps all the lines, making it hard to read in the GitHub UI. I've
added a `-` to lines where this unwanted wrapping happens, to improve
readability, and also fixed some capitalisation errors and a broken link.