### PR TITLE
Use go 1.12 on travis and golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+service:
+  golangci-lint-version: 1.16.0
 linters:
   enable-all: true
   disable:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: go
 env:
   - GO111MODULE=on
 go:
-  - 1.11.x
+  - "1.12.x"
 before_script:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.13.2
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
 script:
   - golangci-lint run
   - go test -v -race -coverprofile=coverage.out -covermode=atomic ./...


### PR DESCRIPTION
Update the travis config to use version 1.12.x of Go.

Update the golangci-lint version to v1.16.0, which is compatible
with go 1.12. Do this is both .travis.yml and .golangci.yml - the
latter is used by the direct GitHub integration with https://golangci.com.
However, the golangci.com integration still uses Go 1.11.X and there is
no way to tell it to use a later version. This means there may be GitHub
check errors for the linter when using Go 1.12 library methods, but that
is not a required check so it won't block merging. This is the best we
can do until the golangci.com service runs with Go 1.12.

The version of Go we say to use in the README.md is Go 1.12, but the CI
and linter uses Go 1.11. Oops. Fix this to use 1.12.

According to https://docs-staging.travis-ci.com/user/languages/go/#specifying-a-go-version-to-use
any tagged version of Go is usable by travis, but doesn't say what
"tagged" means.  It does tell us it uses "gimme" to install go, and
it looks at https://golang.org/dl/ for available versions. So 1.12.x
is a valid version as of now (stable is go1.12.5).

We could drop the version completely and just always get the latest
stable version by default, but we want to ensure that the travis Go
version and the golangci-lint Go version are the same(-ish).
golangci-lint highly recommends a specific version be installed so the
behaviour does not change unexpectedly so builds are repeatable
(https://github.com/golangci/golangci-lint/blob/master/README.md).

Use a string for the travis Go version as certain versions (1.10 for
example) are parsed as numbers which change the version (1.10 becomes
1.1). So just always use strings.

golangci-lint v1.16.0 is the current latest version according to the
github releases page for it
(https://github.com/golangci/golangci-lint/releases/tag/v1.16.0)

Fixes #198 