### PR TITLE
Complete lab05 - Stringer

### DIFF
--- a/05_stringer/n0npax/main.go
+++ b/05_stringer/n0npax/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// IPAddr is a type to encapsulate IPv4 (4 bytes)
+type IPAddr [4]byte
+
+// Stringer for IPAddr
+func (addr IPAddr) String() string {
+	values := make([]string, len(addr))
+	for i, v := range addr {
+		values[i] = fmt.Sprint(v)
+	}
+	return strings.Join(values, ".")
+}
+
+var out io.Writer = os.Stdout
+
+func main() {
+	fmt.Fprintln(out, IPAddr{127, 0, 0, 1})
+}

--- a/05_stringer/n0npax/main.go
+++ b/05_stringer/n0npax/main.go
@@ -4,19 +4,12 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 )
 
-// IPAddr is a type to encapsulate IPv4 (4 bytes)
 type IPAddr [4]byte
 
-// Stringer for IPAddr
 func (addr IPAddr) String() string {
-	values := make([]string, len(addr))
-	for i, v := range addr {
-		values[i] = fmt.Sprint(v)
-	}
-	return strings.Join(values, ".")
+	return fmt.Sprintf("%d.%d.%d.%d", addr[0], addr[1], addr[2], addr[3])
 }
 
 var out io.Writer = os.Stdout

--- a/05_stringer/n0npax/main_test.go
+++ b/05_stringer/n0npax/main_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strconv"
 	"testing"
+
+	assertion "github.com/stretchr/testify/assert"
 )
 
 func TestMainOutput(t *testing.T) {
@@ -33,17 +35,15 @@ func TestStringify(t *testing.T) {
 		"mask 32":              {input: IPAddr{255, 255, 255, 255}, expected: "255.255.255.255"},
 		"mask 0":               {input: IPAddr{0, 0, 0, 0}, expected: "0.0.0.0"},
 		"anz":                  {input: IPAddr{202, 2, 59, 40}, expected: "202.2.59.40"},
+		"empty":                {input: IPAddr{}, expected: "0.0.0.0"},
+		"half-empty":           {input: IPAddr{10, 10}, expected: "10.10.0.0"},
 	}
 	for name, test := range testCases {
-		t.Run(name, helperTestStringify(test.input, test.expected))
-	}
-}
-
-func helperTestStringify(input IPAddr, expected string) func(*testing.T) {
-	return func(t *testing.T) {
-		actual := input.String()
-		if actual != expected {
-			t.Errorf("Expected: %q - Actual: %q", expected, actual)
-		}
+		input, expected := test.input, test.expected
+		t.Run(name, func(t *testing.T) {
+			assert := assertion.New(t)
+			actual := input.String()
+			assert.Equalf(expected, actual, "Testcase %s failed")
+		})
 	}
 }

--- a/05_stringer/n0npax/main_test.go
+++ b/05_stringer/n0npax/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+)
+
+func TestMainOutput(t *testing.T) {
+	var buf bytes.Buffer
+	out = &buf
+
+	main()
+
+	expected := strconv.Quote("127.0.0.1\n")
+	actual := strconv.Quote(buf.String())
+
+	if expected != actual {
+		t.Errorf("Unexpected output. Expected: %q - Actual: %q", expected, actual)
+	}
+}
+
+func TestStringify(t *testing.T) {
+	testCases := map[string]struct {
+		input    IPAddr
+		expected string
+	}{
+		"localhost":            {input: IPAddr{127, 0, 0, 1}, expected: "127.0.0.1"},
+		"google primary dns":   {input: IPAddr{8, 8, 8, 8}, expected: "8.8.8.8"},
+		"google secondary dns": {input: IPAddr{8, 8, 4, 4}, expected: "8.8.4.4"},
+		"CloudFare":            {input: IPAddr{1, 1, 1, 1}, expected: "1.1.1.1"},
+		"mask 24":              {input: IPAddr{255, 255, 255, 0}, expected: "255.255.255.0"},
+		"mask 32":              {input: IPAddr{255, 255, 255, 255}, expected: "255.255.255.255"},
+		"mask 0":               {input: IPAddr{0, 0, 0, 0}, expected: "0.0.0.0"},
+		"anz":                  {input: IPAddr{202, 2, 59, 40}, expected: "202.2.59.40"},
+	}
+	for name, test := range testCases {
+		t.Run(name, helperTestStringify(test.input, test.expected))
+	}
+}
+
+func helperTestStringify(input IPAddr, expected string) func(*testing.T) {
+	return func(t *testing.T) {
+		actual := input.String()
+		if actual != expected {
+			t.Errorf("Expected: %q - Actual: %q", expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Implement IPAddr Stringer method
Add tests

Fixes #214 

Review of colleague's PR #213

#### Changes proposed in this PR:

Add `IPAddr` type backed by an array of 4 bytes
Add `String` method for `IPAddr`
Add unit tests

