### PR TITLE
Lab 5 - Stringer

### DIFF
--- a/05_stringer/marksomething/main.go
+++ b/05_stringer/marksomething/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var out io.Writer = os.Stdout
+
+// IPAddr is an IPv4 Address
+type IPAddr [4]byte
+
+func (a IPAddr) String() string {
+	return fmt.Sprint(a[0], ".", a[1], ".", a[2], ".", a[3])
+}
+
+func main() {
+	fmt.Fprintln(out, IPAddr{127, 0, 0, 1})
+}

--- a/05_stringer/marksomething/main_test.go
+++ b/05_stringer/marksomething/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringer(t *testing.T) {
+	testCases := map[string]struct {
+		arg      IPAddr
+		expected string
+	}{
+		"Empty": {
+			arg:      IPAddr{},
+			expected: "0.0.0.0",
+		},
+		"Partial": {
+			arg:      IPAddr{127},
+			expected: "127.0.0.0",
+		},
+		"LocalHost": {
+			arg:      IPAddr{127, 0, 0, 1},
+			expected: "127.0.0.1",
+		},
+		"Common Local": {
+			arg:      IPAddr{192, 168, 0, 1},
+			expected: "192.168.0.1",
+		},
+		"Common Local Broadcast": {
+			arg:      IPAddr{192, 168, 0, 255},
+			expected: "192.168.0.255",
+		},
+	}
+
+	for testName, tC := range testCases {
+		testCase := tC
+		t.Run(testName, func(t *testing.T) {
+			actualFmt := fmt.Sprint(testCase.arg)
+			actualString := testCase.arg.String()
+
+			expected := testCase.expected
+			assert.Equal(t, expected, actualFmt)
+			assert.Equal(t, expected, actualString)
+		})
+	}
+}
+
+func TestMain(t *testing.T) {
+	var buf bytes.Buffer
+	out = &buf
+
+	main()
+
+	actual := buf.String()
+	expected := "127.0.0.1\n"
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Fixes #362 

Review of colleague's PR #277

#### Changes proposed in this PR:
* type IPAddr represents a IPv4 address and implements Stringer
  unspecified bytes are defaulted to 0
* main() prints the localhost IPv4 address followed by newline
