### PR TITLE
Lab05 - Stringers

### DIFF
--- a/05_stringer/willshen8/stringer.go
+++ b/05_stringer/willshen8/stringer.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var out io.Writer = os.Stdout
+
+type IPAddr [4]byte
+
+func (ip IPAddr) String() string {
+	return fmt.Sprintf("%v.%v.%v.%v", ip[0], ip[1], ip[2], ip[3])
+}
+
+func main() {
+	fmt.Fprintln(out, IPAddr{127, 0, 0, 1})
+}

--- a/05_stringer/willshen8/stringer_test.go
+++ b/05_stringer/willshen8/stringer_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMainOutput(t *testing.T) {
+	var buf bytes.Buffer
+	out = &buf
+	main()
+	expected := "127.0.0.1\n"
+	actual := buf.String()
+
+	assert.Equal(t, expected, actual)
+}
+
+var tests = []struct {
+	name     string
+	input    IPAddr
+	expected string
+}{
+	{name: "Unspecified IP Address", input: IPAddr{}, expected: "0.0.0.0"},
+	{name: "Empty IP Address", input: IPAddr{0, 0, 0, 0}, expected: "0.0.0.0"},
+	{name: "One Octet IP Address", input: IPAddr{127}, expected: "127.0.0.0"},
+	{name: "Two Octets IP Address", input: IPAddr{127, 0}, expected: "127.0.0.0"},
+	{name: "Three Octets IP Address", input: IPAddr{127, 0, 1}, expected: "127.0.1.0"},
+	{name: "Broadcast IP Address", input: IPAddr{255, 255, 255, 255}, expected: "255.255.255.255"},
+}
+
+func TestStringer(t *testing.T) {
+
+	for i := range tests {
+		i := i
+		t.Run(tests[i].name, func(t *testing.T) {
+			assert.Equal(t, tests[i].expected, tests[i].input.String())
+		})
+	}
+}


### PR DESCRIPTION
Fixes #368 

Review of colleague's PR #363 

#### Changes proposed in this PR:

## - Stringers lab
- Make type IPAddr
- Implement fmt.stringer to be able to print it as a string in IP address format
- Test cases 
