### PR TITLE
travis: Change golangci-lint download script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
 go:
   - "1.12.x"
 before_script:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -x -- -b $(go env GOPATH)/bin v1.16.0
 script:
   - golangci-lint run
   - go test -v -race -coverprofile=coverage.out -covermode=atomic ./...


### PR DESCRIPTION
Travis is currently failing when running the script to download
golangci-lint, with little output to help show what's going wrong:
    
$ curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
golangci/golangci-lint info checking GitHub for tag 'v1.16.0'
golangci/golangci-lint info found version: 1.16.0 for v1.16.0/linux/amd64
The command "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0" failed and exited with 1 during .
    
Pull the script directly from golangci-lint's github repo instead of
using install.goreleaser.com, which seems to be breaking the download
script.