### PR TITLE
Implement type for IP address with stringer interface plus tests

### DIFF
--- a/05_stringer/runnerdave/main.go
+++ b/05_stringer/runnerdave/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// IPAddr represents an IP address
+type IPAddr [4]byte
+
+var out io.Writer = os.Stdout
+
+func (ip IPAddr) String() string {
+	return fmt.Sprintf("%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3])
+}
+
+func main() {
+	fmt.Fprintln(out, IPAddr{127, 0, 0, 1})
+}

--- a/05_stringer/runnerdave/main_test.go
+++ b/05_stringer/runnerdave/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+)
+
+func TestMainOutput(t *testing.T) {
+	var buf bytes.Buffer
+	out = &buf
+
+	main()
+
+	expected := strconv.Quote("127.0.0.1\n")
+	actual := strconv.Quote(buf.String())
+	t.Logf("expected:%s", expected)
+	t.Logf("actual:%s", actual)
+
+	if expected != actual {
+		t.Errorf("Unexpected output in main()")
+	}
+}
+
+func TestStringer(t *testing.T) {
+	tables := []struct {
+		input  IPAddr
+		output string
+	}{
+		{IPAddr{127, 0, 0, 1}, "127.0.0.1"},
+		{IPAddr{10, 0, 0, 1}, "10.0.0.1"},
+		{IPAddr{191, 255, 255, 255}, "191.255.255.255"},
+		{IPAddr{10, 10}, "10.10.0.0"},
+		{IPAddr{}, "0.0.0.0"},
+	}
+
+	for _, table := range tables {
+		expected := table.output
+		actual := table.input.String()
+		if expected != actual {
+			t.Errorf("Stringer of (%#v) was incorrect, got: %s, want: %s.", table.input, actual, expected)
+		}
+	}
+}


### PR DESCRIPTION
Fixes [#70](https://github.com/anz-bank/go-course/issues/70) 

Review of colleague's PR #366 

#### Changes proposed in this PR:

 - Write tests for a function int the spec in Readme.md
 - Implement type for IPAddr that represents an IP address
 - Implement stringer interface for this type
 - Pass tests
