### PR TITLE
Lab 5 - Created IPAddr data type

### DIFF
--- a/05_stringer/joel00wood/main.go
+++ b/05_stringer/joel00wood/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+)
+
+type IPAddr [4]byte
+
+func (i IPAddr) String() string {
+	return fmt.Sprintf("%v.%v.%v.%v", i[0], i[1], i[2], i[3])
+}
+
+func main() {
+	fmt.Println(IPAddr{127, 0, 0, 1})
+}

--- a/05_stringer/joel00wood/main_test.go
+++ b/05_stringer/joel00wood/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	output "github.com/joel00wood/test-helpers/capture"
+)
+
+func TestMain(t *testing.T) {
+	expected := "127.0.0.1\n"
+	actual := output.CaptureOutput(func() { main() })
+	if expected != actual {
+		t.Errorf("Unexpected result in main(), expected=%q, got=%q",
+			expected, actual)
+	}
+}
+
+func TestIPAddr(t *testing.T) {
+	testCases := map[string]struct {
+		input    IPAddr
+		expected string
+	}{
+		"Standard input": {
+			IPAddr{127, 0, 0, 1},
+			"127.0.0.1",
+		},
+		"googleDNS": {
+			IPAddr{8, 8, 8, 8},
+			"8.8.8.8",
+		},
+		"Empty input": {
+			IPAddr{},
+			"0.0.0.0",
+		},
+		"Partially initialised": {
+			IPAddr{4, 20},
+			"4.20.0.0",
+		},
+	}
+
+	for name, test := range testCases {
+		actual := test.input.String()
+		if test.expected != actual {
+			t.Errorf("Unexpected response for %v, expected=%q, got=%q",
+				name, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Overwrote `.String()` implementation to output underlying byte slice `{0,0,0,0}` as \'0.0.0.0\'

Fixes  #393

Review of colleague's PR #452

#### Changes proposed in this PR:
- IPAddr data type
- Overwrites underlying `.String()` to format output as an IP v4 Address