### PR TITLE
Add @pentaphobe to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @anzboi @anzdaddy @camh-anz @Joshcarp @juliaogris @linuxmonk @rokane
+*  @anzboi @anzdaddy @camh-anz @Joshcarp @juliaogris @linuxmonk @rokane @pentaphobe


### PR DESCRIPTION
One more limb to the Voltron that is course reviewers

#### Changes proposed in this PR:

- addition of one user to CODEOWNERS
