### PR TITLE
Pin golanci-lint-version to 1.17.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 service:
-  golangci-lint-version: 1.16.0
+  golangci-lint-version: 1.17.1
 linters:
   enable-all: true
   disable:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
 go:
   - "1.12.x"
 before_script:
-  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -x -- -b $(go env GOPATH)/bin v1.16.0
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -x -- -b $(go env GOPATH)/bin v1.17.1
 script:
   - golangci-lint run
   - go test -v -race -coverprofile=coverage.out -covermode=atomic ./...

--- a/01_fib/brnbke/main_test.go
+++ b/01_fib/brnbke/main_test.go
@@ -71,7 +71,7 @@ func TestAbs(t *testing.T) {
 		input int
 		want  int
 	}{
-		"positve":  {input: 2, want: 2},
+		"positive": {input: 2, want: 2},
 		"negative": {input: -3, want: 3},
 		"zero":     {input: 0, want: 0},
 	}

--- a/03_letters/n0npax/main_test.go
+++ b/03_letters/n0npax/main_test.go
@@ -103,7 +103,7 @@ func helperTestSortLetters(name string, input map[rune]int, expected []string) f
 				t.Errorf("Test: %s - Expect: %s got: %s", name, expected[i], v)
 			}
 		}
-		assert.Equalf(t, len(expected), len(result), "Lenght missmatch")
+		assert.Equalf(t, len(expected), len(result), "Length mismatch")
 	}
 }
 


### PR DESCRIPTION
pin golang-lint-version to 1.17.1 to keep tools up to date.