### PR TITLE
Lab 6 CRUD Puppy

### DIFF
--- a/06_puppy/marksomething/main.go
+++ b/06_puppy/marksomething/main.go
@@ -1,0 +1,91 @@
+package main
+
+import "sync"
+
+// Puppy represents a small dog
+type Puppy struct {
+	ID     uint32
+	Breed  string
+	Colour string
+	Value  int
+}
+
+// PuppyStorer stores an object in a key-value store
+type PuppyStorer interface {
+	CreatePuppy(p Puppy)
+	ReadPuppy(k uint32) Puppy
+	UpdatePuppy(k uint32, p Puppy)
+	DeletePuppy(k uint32)
+}
+
+// MapStore is a storage mechanism for Puppy
+type MapStore map[uint32]Puppy
+
+// CreatePuppy adds a Puppy to storage unless a Puppy of the same ID is stored in which case nothing is done
+func (m MapStore) CreatePuppy(p Puppy) {
+	if _, found := m[p.ID]; found {
+		return
+	}
+	m[p.ID] = p
+}
+
+// ReadPuppy returns a Puppy from storage, or a blank Puppy where no Puppy of that id is found
+func (m MapStore) ReadPuppy(id uint32) Puppy {
+	return m[id]
+}
+
+// UpdatePuppy updates an existing puppy if id matches the Puppy and id is found in the storage, otherwise nothing
+func (m MapStore) UpdatePuppy(id uint32, p Puppy) {
+	if id != p.ID {
+		return
+	}
+	if _, ok := m[id]; !ok {
+		return
+	}
+	m[id] = p
+}
+
+// DeletePuppy removes a puppy from storage if it exists
+func (m MapStore) DeletePuppy(id uint32) {
+	delete(m, id)
+}
+
+// SyncStore is a storage mechanism for Puppy
+type SyncStore struct{ sync.Map }
+
+// CreatePuppy adds a Puppy to storage unless a Puppy of the same ID is stored in which case nothing is done
+func (s *SyncStore) CreatePuppy(p Puppy) {
+	if _, found := s.Load(p.ID); found {
+		return
+	}
+	s.Store(p.ID, p)
+}
+
+// ReadPuppy returns a Puppy from storage, or a blank Puppy where no Puppy of that id is found
+func (s *SyncStore) ReadPuppy(id uint32) Puppy {
+	p, ok := s.Load(id)
+	if !ok {
+		return Puppy{}
+	}
+	return p.(Puppy)
+}
+
+// UpdatePuppy updates an existing puppy if id matches the Puppy and id is found in the storage, otherwise nothing
+func (s *SyncStore) UpdatePuppy(id uint32, p Puppy) {
+	if id != p.ID {
+		return
+	}
+	if _, ok := s.Load(id); !ok {
+		return
+	}
+	s.Store(id, p)
+}
+
+// DeletePuppy removes a puppy from storage if it exists
+func (s *SyncStore) DeletePuppy(id uint32) {
+	s.Delete(id)
+}
+
+func main() {
+
+}

--- a/06_puppy/marksomething/main_test.go
+++ b/06_puppy/marksomething/main_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type PuppyStorerTest struct {
+	suite.Suite
+	store        PuppyStorer
+	storeFactory func() PuppyStorer
+}
+
+// Create a new instance of PuppyStorer for each test case
+func (suite *PuppyStorerTest) SetupTest() {
+	suite.store = suite.storeFactory()
+}
+
+func (suite *PuppyStorerTest) TestReadNonExistantPuppy() {
+	expected := Puppy{}
+
+	actual := suite.store.ReadPuppy(99)
+
+	suite.Equal(expected, actual)
+}
+
+func (suite *PuppyStorerTest) TestUpdateNonExistantPuppy() {
+	newPuppy := Puppy{1, "Lab", "Brown", 1}
+	expected := Puppy{}
+
+	suite.store.UpdatePuppy(1, newPuppy)
+	actual := suite.store.ReadPuppy(1)
+
+	suite.Equal(expected, actual)
+}
+
+func (suite *PuppyStorerTest) TestUpdatePuppyBadId() {
+	expected := Puppy{1, "Lab", "Brown", 1}
+	differentPuppy := Puppy{7, "Poodle", "Brown", 1}
+
+	suite.store.CreatePuppy(expected)
+
+	suite.store.UpdatePuppy(1, differentPuppy)
+	actual := suite.store.ReadPuppy(1)
+	suite.Equal(expected, actual)
+
+	differentPuppyFromStorage := suite.store.ReadPuppy(7)
+	blankPuppy := Puppy{}
+	suite.Equal(blankPuppy, differentPuppyFromStorage)
+}
+
+func (suite *PuppyStorerTest) TestCreateReadPuppy() {
+	expected := Puppy{1, "Lab", "Brown", 1}
+
+	suite.store.CreatePuppy(expected)
+
+	actual := suite.store.ReadPuppy(1)
+	suite.Equal(expected, actual)
+}
+
+func (suite *PuppyStorerTest) TestDoubleCreatePuppy() {
+	expected := Puppy{1, "Lab", "Brown", 1}
+
+	suite.store.CreatePuppy(expected)
+	suite.store.CreatePuppy(expected)
+
+	actual := suite.store.ReadPuppy(1)
+	suite.Equal(expected, actual)
+}
+
+func (suite *PuppyStorerTest) TestCreateDeleteReadPuppy() {
+	expected := Puppy{}
+
+	suite.store.CreatePuppy(Puppy{1, "Lab", "Brown", 1})
+	suite.store.DeletePuppy(1)
+	actual := suite.store.ReadPuppy(1)
+
+	suite.Equal(expected, actual)
+}
+
+func (suite *PuppyStorerTest) TestDeleteNonExistantPuppy() {
+	expected := suite.store
+	suite.store.DeletePuppy(1)
+	suite.Equal(expected, suite.store)
+}
+
+func (suite *PuppyStorerTest) TestCreateReadMultiplePuppy() {
+	expected1 := Puppy{1, "Lab", "Brown", 1}
+	expected2 := Puppy{2, "Poodle", "Blue", 2}
+
+	suite.store.CreatePuppy(expected1)
+	suite.store.CreatePuppy(expected2)
+	actual1 := suite.store.ReadPuppy(1)
+	actual2 := suite.store.ReadPuppy(2)
+
+	suite.Equal(expected1, actual1)
+	suite.Equal(expected2, actual2)
+}
+
+func (suite *PuppyStorerTest) TestCreateUpdateReadPuppy() {
+	originalPuppy := Puppy{1, "Lab", "Brown", 32}
+	modifiedPuppy := Puppy{1, "Lab", "Brown", 22}
+
+	suite.store.CreatePuppy(originalPuppy)
+	suite.store.UpdatePuppy(1, modifiedPuppy)
+
+	actual := suite.store.ReadPuppy(1)
+	suite.Equal(modifiedPuppy, actual)
+}
+
+func TestMapStore(t *testing.T) {
+	s := PuppyStorerTest{
+		storeFactory: func() PuppyStorer { return MapStore{} },
+	}
+	suite.Run(t, &s)
+}
+
+func TestSyncStore(t *testing.T) {
+	s := PuppyStorerTest{
+		storeFactory: func() PuppyStorer { return &SyncStore{} },
+	}
+	suite.Run(t, &s)
+}


### PR DESCRIPTION
Fixes #442 

Review of colleague's PR #476

#### Changes proposed in this PR:

Implement minimal CRUD Puppy Storage whilst
avoiding implementing the requirements of Lab 7
All error cases are silently ignored

- CreatePuppy stores a Puppy at the ID in the Puppy unless one is already present
- ReadPuppy returns the puppy at the ID given, or a nil Puppy if not found
- UpdatePuppy replaces the Puppy at the ID given if there is a Puppy there and
  the replacement Puppy shares the same ID
- DeletePuppy deletes the Puppy at the given ID if one exists