### PR TITLE
Feature/lab 5

### DIFF
--- a/05_stringer/starfallz/main.go
+++ b/05_stringer/starfallz/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+var out io.Writer = os.Stdout
+
+func main() {
+	fmt.Fprint(out, IPAddr{127, 0, 0, 1})
+}
+
+type IPAddr struct {
+	add1 uint8
+	add2 uint8
+	add3 uint8
+	add4 uint8
+}
+
+func (ipAddr IPAddr) String() string {
+	return strings.Join([]string{
+		strconv.Itoa(int(ipAddr.add1)),
+		strconv.Itoa(int(ipAddr.add2)),
+		strconv.Itoa(int(ipAddr.add3)),
+		strconv.Itoa(int(ipAddr.add4))}, ".")
+}

--- a/05_stringer/starfallz/main.go
+++ b/05_stringer/starfallz/main.go
@@ -15,10 +15,7 @@ func main() {
 }
 
 type IPAddr struct {
-	add1 uint8
-	add2 uint8
-	add3 uint8
-	add4 uint8
+	add1, add2, add3, add4 uint8
 }
 
 func (ipAddr IPAddr) String() string {

--- a/05_stringer/starfallz/main_test.go
+++ b/05_stringer/starfallz/main_test.go
@@ -29,13 +29,19 @@ func TestIpAddrDefaultToString(t *testing.T) {
 		expected    string
 	}{
 		{"Test IPAddr with all zeros in addresses", IPAddr{0, 0, 0, 0}, "0.0.0.0"},
+		{"Test IPAddr with some values assigned", IPAddr{add1: 5, add4: 4}, "5.0.0.4"},
+		{"Test IPAddr with no value", IPAddr{}, "0.0.0.0"},
+		{"Test IPAddr with max values allowed on uint8", IPAddr{255, 255, 255, 255}, "255.255.255.255"},
 	}
 
 	for _, testCase := range testCases {
+		input := testCase.input
+		expected := testCase.expected
+
 		t.Run(testCase.description, func(t *testing.T) {
-			actual := testCase.input.String()
-			if testCase.expected != actual {
-				t.Errorf("Unexpected output, expected: %s, actual: %s", testCase.expected, actual)
+			actual := input.String()
+			if expected != actual {
+				t.Errorf("Unexpected output, expected: %s, actual: %s", expected, actual)
 			}
 		})
 	}

--- a/05_stringer/starfallz/main_test.go
+++ b/05_stringer/starfallz/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+)
+
+func TestMainFunction(t *testing.T) {
+	t.Run("Test main to return string values of IPAddr({127, 0, 0, 1}) with proper formatting", func(t *testing.T) {
+		var buf bytes.Buffer
+		out = &buf
+
+		main()
+
+		expected := strconv.Quote("127.0.0.1")
+		actual := strconv.Quote(buf.String())
+
+		if expected != actual {
+			t.Errorf("Unexpected output, expected: %s, actual: %s", expected, actual)
+		}
+	})
+}
+
+func TestIpAddrDefaultToString(t *testing.T) {
+	testCases := []struct {
+		description string
+		input       IPAddr
+		expected    string
+	}{
+		{"Test IPAddr with all zeros in addresses", IPAddr{0, 0, 0, 0}, "0.0.0.0"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			actual := testCase.input.String()
+			if testCase.expected != actual {
+				t.Errorf("Unexpected output, expected: %s, actual: %s", testCase.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #462

Review of colleague's PR #

#### Changes proposed in this PR:

- Make the `IPAddr` type implement `fmt.Stringer` to print the address as a dotted quad
