### PR TITLE
modules: Change module name to go-course from go-training

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/anz-bank/go-training
+module github.com/anz-bank/go-course
 
 require github.com/stretchr/testify v1.3.0


### PR DESCRIPTION
When the repository was renamed from go-training to go-course, the
go.mod file was not updated to reflect the new name.

Fixes #479 