### PR TITLE
Implement fibonacci sequence for positive integers

### DIFF
--- a/01_fib/undrewb/main.go
+++ b/01_fib/undrewb/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+var out io.Writer = os.Stdout
+
+func main() {
+	_ = fib(7)
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func fibonacciSign(n int) int {
+	if n < 0 {
+		return [2]int{1, -1}[abs(n+1)%2]
+	}
+	return 1
+}
+
+func fib(n int) error {
+	// I have picked an arbitrary limit because this
+	// is a learning exercise
+	if n > 60 || n < -60 {
+		return errors.New("fib only works between 60 and -60")
+	}
+
+	if n >= 0 {
+		//  iterate up
+		for idx := 0; idx <= n; idx++ {
+			fmt.Fprintln(out, fibonacci(idx))
+		}
+	} else {
+		// iterate down
+		for idx := 0; idx >= n; idx-- {
+			fmt.Fprintln(out, fibonacci(idx))
+		}
+	}
+	return nil
+}
+
+func fibonacci(n int) int {
+	return fibonacciSign(n) * fibonacciLoop(abs(n))
+}
+
+// could optimise this by passing in the last fibonacci
+// number for this particular example but for a general
+// case lets not assume we have context
+
+func fibonacciLoop(n int) int {
+	if n < 2 {
+		return n
+	}
+	result := 0
+	fibNum1 := 0
+	fibNum2 := 1
+	for idx := 2; idx <= n; idx++ {
+		result = fibNum1 + fibNum2
+		fibNum1 = fibNum2
+		fibNum2 = result
+	}
+	return result
+}

--- a/01_fib/undrewb/main_test.go
+++ b/01_fib/undrewb/main_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+)
+
+func TestMainOutput(t *testing.T) {
+	var buf bytes.Buffer
+	out = &buf
+
+	main()
+
+	expected := strconv.Quote("0\n1\n1\n2\n3\n5\n8\n13\n")
+	actual := strconv.Quote(buf.String())
+
+	if expected != actual {
+		t.Errorf("unexpected result in main()")
+	}
+}
+
+func TestFibNegativeOutput(t *testing.T) {
+	var buf bytes.Buffer
+	out = &buf
+
+	if fib(-7) != nil {
+		t.Errorf("ufib(-7) unexpectedly threw an error")
+	}
+
+	expected := strconv.Quote("0\n1\n-1\n2\n-3\n5\n-8\n13\n")
+	actual := strconv.Quote(buf.String())
+
+	if expected != actual {
+		t.Errorf("unexpected result in negative fib")
+	}
+}
+
+func TestOverflowError(t *testing.T) {
+	if fib(61) == nil {
+		t.Errorf("fib(61) should have returned an error")
+	}
+}
+
+func TestUnderflowError(t *testing.T) {
+	if fib(-61) == nil {
+		t.Errorf("fib(-61) should have returned an error")
+	}
+}
+
+var fibloopTests = []struct {
+	n        int // input
+	expected int // expected result
+}{
+	{1, 1},
+	{2, 1},
+	{3, 2},
+	{4, 3},
+	{5, 5},
+	{6, 8},
+	{7, 13},
+}
+
+func TestFibonacciLoop(t *testing.T) {
+	for _, tt := range fibloopTests {
+		actual := fibonacciLoop(tt.n)
+		if actual != tt.expected {
+			t.Errorf("fibonacciLoop(%d): expected %d, actual %d", tt.n, tt.expected, actual)
+		}
+	}
+}
+
+var fibTests = []struct {
+	n        int // input
+	expected int // expected result
+}{
+	{1, 1},
+	{2, 1},
+	{3, 2},
+	{4, 3},
+	{5, 5},
+	{6, 8},
+	{7, 13},
+	{-1, 1},
+	{-2, -1},
+	{-3, 2},
+	{-4, -3},
+	{-5, 5},
+	{-6, -8},
+	{-7, 13},
+}
+
+func TestFibonacci(t *testing.T) {
+	for _, tt := range fibTests {
+		actual := fibonacci(tt.n)
+		if actual != tt.expected {
+			t.Errorf("fibonacci(%d): expected %d, actual %d", tt.n, tt.expected, actual)
+		}
+	}
+}
+
+var signTests = []struct {
+	n        int // input
+	expected int // expected result
+}{
+	{-6, -1},
+	{-4, -1},
+	{-3, 1},
+	{6, 1},
+	{2, 1},
+}
+
+func TestFibonacciSign(t *testing.T) {
+	for _, tt := range signTests {
+		actual := fibonacciSign(tt.n)
+		if actual != tt.expected {
+			t.Errorf("fibonacciSign(%d): expected %d, actual %d", tt.n, tt.expected, actual)
+		}
+	}
+}
+
+var absTests = []struct {
+	n        int // input
+	expected int // expected result
+}{
+	{-6, 6},
+	{-4, 4},
+	{-3, 3},
+	{6, 6},
+	{2, 2},
+}
+
+func TestAbs(t *testing.T) {
+	for _, tt := range absTests {
+		actual := abs(tt.n)
+		if actual != tt.expected {
+			t.Errorf("abs(%d): expected %d, actual %d", tt.n, tt.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Uses the definition of fibonacci sequence in wikipedia.
https://en.wikipedia.org/wiki/Fibonacci_number
Outputs 0 for the 0th fibonccia entry.
The implementation uses a recursive method.
It is for lab 01 of the go-couse.
https://github.com/undrewb/go-course/tree/master/01_fib

Add overflow check

Limit fibonacci call to n<=20 so that there won't be an overflow.

Implement negafibonacci

Added a sign evaluation if starting n is less than 0.
This works per the wikipedia article about fibonacci.

Resolve issues with negafibonacci

Negafibonacci is now easier to test.
Sign only takes one parameter - assumes it is being called only by negafibonacci.

Resolve linting errors

Added table tests to remove repetitive tests

Added underflow check for -20

Address issues raised in PR #213

1. Use more efficient approach for calculating sign.
Using an array lookup is faster than using pow.
2. Use table tests for sign unit testing.
Removes repetition.

Integrate feedback from #PR213

Rework logic and test based on PR feedback

Add unit test for underflow and overflow panics

Integrate PR feedback

Use loop instead of recursion
Replace panic for overflow and underflow with error printing

Use error to report out of bounds errors

Remove error check from main to ensure 100% test coverage

Remove unused import

Remove err variable from main

Fixes #

Review of colleague's PR #

#### Changes proposed in this PR:

## -
