### PR TITLE
Lab4 - Add numeronyms function

### DIFF
--- a/04_numeronym/davidbroughsmyth/main.go
+++ b/04_numeronym/davidbroughsmyth/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"unicode/utf8"
+)
+
+var out io.Writer = os.Stdout
+
+func numeronyms(vals ...string) []string {
+	result := make([]string, len(vals))
+	for i, val := range vals {
+		c := utf8.RuneCountInString(val)
+		if c > 3 {
+			f, _ := utf8.DecodeRuneInString(val)
+			l, _ := utf8.DecodeLastRuneInString(val)
+			val = fmt.Sprintf("%c%d%c", f, c-2, l)
+		}
+		result[i] = val
+	}
+	return result
+}
+
+func main() {
+	fmt.Fprintln(out, numeronyms("accessibility", "Kubernetes", "abc"))
+}

--- a/04_numeronym/davidbroughsmyth/main_test.go
+++ b/04_numeronym/davidbroughsmyth/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMainOutput(t *testing.T) {
+	var buf bytes.Buffer
+	out = &buf
+	main()
+	expected := strconv.Quote("[a11y K8s abc]\n")
+	actual := strconv.Quote(buf.String())
+	assert.Equal(t, expected, actual, "Unexpected output from main()")
+}
+
+var tests = map[string]struct {
+	input, want []string
+}{
+	"empty":        {input: []string{}, want: []string{}},
+	"SpecialChars": {input: []string{"@@!##%&&"}, want: []string{"@6&"}},
+	"3unicode":     {input: []string{"😛😸😛"}, want: []string{"😛😸😛"}},
+	"4unicode":     {input: []string{"😛😛😛大"}, want: []string{"😛2大"}},
+	"MixCodes":     {input: []string{"😛@#Xy 大Z2赞"}, want: []string{"😛8赞"}},
+	"Alphanumeric": {
+		input: []string{"8abcABC5Z", "cAt", "b1Rd"},
+		want:  []string{"87Z", "cAt", "b2d"},
+	},
+	"MaryPoppins": {
+		input: []string{"It's", "supercalifragilisticexpialidocious"},
+		want:  []string{"I2s", "s32s"},
+	},
+}
+
+func TestNumeronyms(t *testing.T) {
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			got := numeronyms(test.input...)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #546 

Review of colleague's PR #386 

#### Changes proposed in this PR:

 - Create `function numeronyms(vals ...string) []string` 
- When passed in "accessibility", "Kubernetes", "abc" returns a slice [a11y K8s abc]
- numeronyms supports unicode characters



