### PR TITLE
Lab5 - Add IPAddr type and implement fmt.Stringer

### DIFF
--- a/05_stringer/davidbroughsmyth/main.go
+++ b/05_stringer/davidbroughsmyth/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var out io.Writer = os.Stdout
+
+type IPAddr [4]byte
+
+func (ip4 IPAddr) String() string {
+	return fmt.Sprintf("%d.%d.%d.%d", ip4[0], ip4[1], ip4[2], ip4[3])
+}
+
+func main() {
+	fmt.Fprintln(out, IPAddr{127, 0, 0, 1})
+}

--- a/05_stringer/davidbroughsmyth/main_test.go
+++ b/05_stringer/davidbroughsmyth/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMainOutput(t *testing.T) {
+	var buf bytes.Buffer
+	out = &buf
+	main()
+	expected := strconv.Quote("127.0.0.1\n")
+	actual := strconv.Quote(buf.String())
+	assert.Equal(t, expected, actual, "Unexpected output from main()")
+}
+
+var tests = map[string]struct {
+	input IPAddr
+	want  string
+}{
+	"Empty":     {input: IPAddr{}, want: "0.0.0.0"},
+	"Loopback":  {input: IPAddr{127, 0, 0, 1}, want: "127.0.0.1"},
+	"Partial":   {input: IPAddr{0, 255}, want: "0.255.0.0"},
+	"Broadcast": {input: IPAddr{255, 255, 255, 255}, want: "255.255.255.255"},
+	"Zero mask": {input: IPAddr{0, 0, 0, 0}, want: "0.0.0.0"},
+	"Local lan": {input: IPAddr{192, 168, 0, 1}, want: "192.168.0.1"},
+}
+
+func TestIPAddr(t *testing.T) {
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			got := test.input.String()
+			assert.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION


Fixes #548 

Review of colleague's PR #388 

#### Changes proposed in this PR:
- Create new IPAddr type `IPAddr [4]byte`
- create fmt.Stringer to print IP address as a dotted quad
