### PR TITLE
Implement Lab5 Stringer and tests

### DIFF
--- a/05_stringer/sirigithub/main.go
+++ b/05_stringer/sirigithub/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var out io.Writer = os.Stdout
+
+type IPAddr [4]byte
+
+func (ipAdd IPAddr) String() string {
+	return fmt.Sprintf("%d.%d.%d.%d", ipAdd[0], ipAdd[1], ipAdd[2], ipAdd[3])
+}
+
+func main() {
+	fmt.Fprint(out, IPAddr{127, 0, 0, 1})
+}

--- a/05_stringer/sirigithub/main_test.go
+++ b/05_stringer/sirigithub/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMainOutput(t *testing.T) {
+	var buf bytes.Buffer
+	out = &buf
+	main()
+	expected := "127.0.0.1"
+	actual := buf.String()
+	assert.Equal(t, expected, actual, "Unexpected output in main() actual %v but expected %v", actual, expected)
+}
+func TestIPAddrStringer(t *testing.T) {
+
+	testCases := []struct {
+		description string
+		input       IPAddr
+		expected    string
+	}{
+		{description: "Empty", input: IPAddr{}, expected: "0.0.0.0"},
+		{description: "All zeroes", input: IPAddr{0, 0, 0, 0}, expected: "0.0.0.0"},
+		{description: "Single octet", input: IPAddr{115}, expected: "115.0.0.0"},
+		{description: "Two octets", input: IPAddr{115, 70}, expected: "115.70.0.0"},
+		{description: "Three octets", input: IPAddr{115, 70, 166}, expected: "115.70.166.0"},
+		{description: "IP Address", input: IPAddr{115, 70, 166, 151}, expected: "115.70.166.151"},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.description, func(t *testing.T) {
+			actual := test.input.String()
+			expected := test.expected
+			assert.Equal(t, actual, expected, "actual %v but expected %v", actual, expected)
+		})
+	}
+
+}


### PR DESCRIPTION
Fixes #553

Review of colleague's PR #547

#### Changes proposed in this PR:

- Created an executable go program in directory `05_stringer/sirigithub`
- Make the `IPAddr` type implement `fmt.Stringer` to print the address as a dotted quad
- Implemented main function that calls `fmt.Println(IPAddr{127, 0, 0, 1})` to print a dotted quad 127.0.0.1
- Implemented tests for main and the Stringer function.