### PR TITLE
Check if binary file was committed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 before_script:
   - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -x -- -b $(go env GOPATH)/bin v1.17.1
 script:
+  - for f in $(find -executable -type f); do file -i "${f}" | awk '{print $NF}' | grep -q binary && { echo "FAIL - bin file found (${f})"; exit 1; }; done; echo "OK - no bin files"
   - golangci-lint run
   - go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
   - "{ go tool cover -func=coverage.out | grep '^total:.*100.0%'; } || { echo 'FAIL - Coverage below 100%'; exit 1; }"


### PR DESCRIPTION
Fixes #568

Continuation of: #569 - fixed branch name
Review of colleague's PR: N/A

Changes proposed in this PR:
From time to time someone forgets to rm bin files from PR. We can use Travis to check this.