### PR TITLE
Implement custom error handling to Storer interface

### DIFF
--- a/07_errors/patrickmarabeas/errors.go
+++ b/07_errors/patrickmarabeas/errors.go
@@ -1,0 +1,32 @@
+package main
+
+import "fmt"
+
+type ErrorCode int
+
+type Error struct {
+	Code    ErrorCode
+	Message string
+}
+
+const (
+	NegativeValue ErrorCode = iota + 1001
+	IDNotFound
+	Unknown = 1999
+)
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("[%d] %s", e.Code, e.Message)
+}
+
+// NewError creates a new error with the given enum
+func NewError(code ErrorCode) error {
+	switch code {
+	case NegativeValue:
+		return &Error{code, "Puppy value must be greater than 0"}
+	case IDNotFound:
+		return &Error{code, "Nonexistent Puppy ID"}
+	default:
+		return &Error{Unknown, "Unknown error"}
+	}
+}

--- a/07_errors/patrickmarabeas/errors_test.go
+++ b/07_errors/patrickmarabeas/errors_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnknownError(t *testing.T) {
+	a := assert.New(t)
+
+	error := NewError(123)
+	a.Equal(error, NewError(Unknown))
+}
+
+func TestError(t *testing.T) {
+	a := assert.New(t)
+
+	error := Error{1, "message"}
+	formattedError := error.Error()
+	a.Equal(formattedError, "[1] message")
+}

--- a/07_errors/patrickmarabeas/main.go
+++ b/07_errors/patrickmarabeas/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/07_errors/patrickmarabeas/main.go
+++ b/07_errors/patrickmarabeas/main.go
@@ -1,5 +1,13 @@
 package main
 
-func main() {
+import (
+	"fmt"
+	"io"
+	"os"
+)
 
+var out io.Writer = os.Stdout
+
+func main() {
+	fmt.Fprint(out, "hello")
 }

--- a/07_errors/patrickmarabeas/main_test.go
+++ b/07_errors/patrickmarabeas/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+var out io.Writer = os.Stdout
+
+func TestMainOutput(t *testing.T) {
+	var buf bytes.Buffer
+	out = &buf
+
+	main()
+
+	expected := ""
+
+	got := buf.String()
+
+	if expected != got {
+		t.Errorf("\nExpected: %s\nGot: %s", expected, got)
+	}
+}

--- a/07_errors/patrickmarabeas/main_test.go
+++ b/07_errors/patrickmarabeas/main_test.go
@@ -2,12 +2,8 @@ package main
 
 import (
 	"bytes"
-	"io"
-	"os"
 	"testing"
 )
-
-var out io.Writer = os.Stdout
 
 func TestMainOutput(t *testing.T) {
 	var buf bytes.Buffer
@@ -15,7 +11,7 @@ func TestMainOutput(t *testing.T) {
 
 	main()
 
-	expected := ""
+	expected := "hello"
 
 	got := buf.String()
 

--- a/07_errors/patrickmarabeas/mapStore.go
+++ b/07_errors/patrickmarabeas/mapStore.go
@@ -9,43 +9,50 @@ func NewMapStore() Storer {
 }
 
 // Create increments the uuid and adds the provided Puppy struct to the store with this identifier.
-func (store *MapStore) Create(puppy Puppy) int {
+func (store *MapStore) Create(puppy Puppy) (int, error) {
+	if puppy.Value < 0 {
+		return -1, NewError(NegativeValue)
+	}
+
 	puppy.ID = store.uuid
 	store.store[puppy.ID] = puppy
 	store.uuid++
 
-	return puppy.ID
+	return puppy.ID, nil
 }
 
 // Read returns the puppy matching the provided uuid.
 // An empty Puppy struct is returned if the identifier does not exist.
-func (store *MapStore) Read(id int) Puppy {
+func (store *MapStore) Read(id int) (Puppy, error) {
 	if _, ok := store.store[id]; ok {
-		return store.store[id]
+		return store.store[id], nil
 	}
 
-	return Puppy{}
+	return Puppy{}, NewError(IDNotFound)
 }
 
 // Update modifies the puppy matching the provided uuid in the store with the provided Puppy struct.
 // It returns a bool whether a matching identifier was modified or not.
-func (store *MapStore) Update(id int, puppy Puppy) bool {
+func (store *MapStore) Update(id int, puppy Puppy) (bool, error) {
 	if _, ok := store.store[id]; !ok {
-		return false
+		return false, NewError(IDNotFound)
+	}
+	if puppy.Value < 0 {
+		return false, NewError(NegativeValue)
 	}
 
 	puppy.ID = id
 	store.store[id] = puppy
-	return true
+	return true, nil
 }
 
 // Destroy removes the puppy matching the provided uuid from the store.
 // It returns a bool whether a matching identifier was deleted or not.
-func (store *MapStore) Destroy(id int) bool {
+func (store *MapStore) Destroy(id int) (bool, error) {
 	if _, ok := store.store[id]; !ok {
-		return false
+		return false, NewError(IDNotFound)
 	}
 
 	delete(store.store, id)
-	return true
+	return true, nil
 }

--- a/07_errors/patrickmarabeas/mapStore.go
+++ b/07_errors/patrickmarabeas/mapStore.go
@@ -1,0 +1,51 @@
+package main
+
+// NewMapStore returns a pointer to a new instance of the MapStore struct which implements the Storer interface.
+func NewMapStore() Storer {
+	return &MapStore{
+		uuid:  0,
+		store: map[int]Puppy{},
+	}
+}
+
+// Create increments the uuid and adds the provided Puppy struct to the store with this identifier.
+func (store *MapStore) Create(puppy Puppy) int {
+	puppy.ID = store.uuid
+	store.store[puppy.ID] = puppy
+	store.uuid++
+
+	return puppy.ID
+}
+
+// Read returns the puppy matching the provided uuid.
+// An empty Puppy struct is returned if the identifier does not exist.
+func (store *MapStore) Read(id int) Puppy {
+	if _, ok := store.store[id]; ok {
+		return store.store[id]
+	}
+
+	return Puppy{}
+}
+
+// Update modifies the puppy matching the provided uuid in the store with the provided Puppy struct.
+// It returns a bool whether a matching identifier was modified or not.
+func (store *MapStore) Update(id int, puppy Puppy) bool {
+	if _, ok := store.store[id]; !ok {
+		return false
+	}
+
+	puppy.ID = id
+	store.store[id] = puppy
+	return true
+}
+
+// Destroy removes the puppy matching the provided uuid from the store.
+// It returns a bool whether a matching identifier was deleted or not.
+func (store *MapStore) Destroy(id int) bool {
+	if _, ok := store.store[id]; !ok {
+		return false
+	}
+
+	delete(store.store, id)
+	return true
+}

--- a/07_errors/patrickmarabeas/store_test.go
+++ b/07_errors/patrickmarabeas/store_test.go
@@ -14,70 +14,99 @@ type StoreSuite struct {
 
 func (suite *StoreSuite) TestCreate() {
 	a := assert.New(suite.T())
-	id := suite.store.Create(Puppy{Breed: "Wolf", Color: "Grey", Value: "450"})
 
+	id, error := suite.store.Create(Puppy{Breed: "Wolf", Color: "Grey", Value: 450})
 	a.Equal(id, 0)
+	a.Equal(error, nil)
 }
 
 func (suite *StoreSuite) TestCreateSecond() {
 	a := assert.New(suite.T())
-	id := suite.store.Create(Puppy{Breed: "Boxer", Color: "Brown", Value: "300"})
 
+	id, error := suite.store.Create(Puppy{Breed: "Boxer", Color: "Brown", Value: 300})
 	a.Equal(id, 1)
+	a.Equal(error, nil)
+}
+
+func (suite *StoreSuite) TestCreateNegativeNumber() {
+	a := assert.New(suite.T())
+
+	id, error := suite.store.Create(Puppy{Breed: "Wolf", Color: "Grey", Value: -100})
+	a.Equal(id, -1)
+	a.Equal(error, NewError(NegativeValue))
 }
 
 func (suite *StoreSuite) TestRead() {
 	a := assert.New(suite.T())
-	data := suite.store.Read(0)
 
-	a.Equal(data, Puppy{ID: 0, Breed: "Wolf", Color: "Grey", Value: "450"})
+	data, error := suite.store.Read(0)
+	a.Equal(data, Puppy{ID: 0, Breed: "Wolf", Color: "Grey", Value: 450})
+	a.Equal(error, nil)
 }
 
 func (suite *StoreSuite) TestReadNonExistent() {
 	a := assert.New(suite.T())
-	success := suite.store.Read(100)
 
+	success, error := suite.store.Read(100)
 	a.Equal(success, Puppy{})
+	a.Equal(error, NewError(IDNotFound))
 }
 
 func (suite *StoreSuite) TestUpdate() {
 	a := assert.New(suite.T())
-	success := suite.store.Update(0, Puppy{Breed: "Doberman", Color: "Black", Value: "500"})
-	data := suite.store.Read(0)
 
+	success, error := suite.store.Update(0, Puppy{Breed: "Doberman", Color: "Black", Value: 500})
 	a.Equal(success, true)
-	a.Equal(data, Puppy{ID: 0, Breed: "Doberman", Color: "Black", Value: "500"})
+	a.Equal(error, nil)
+
+	data, error := suite.store.Read(0)
+	a.Equal(data, Puppy{ID: 0, Breed: "Doberman", Color: "Black", Value: 500})
+	a.Equal(error, nil)
 }
 
 func (suite *StoreSuite) TestUpdateNonExistent() {
 	a := assert.New(suite.T())
-	success := suite.store.Update(100, Puppy{Breed: "Doberman", Color: "Black", Value: "500"})
 
+	success, error := suite.store.Update(100, Puppy{Breed: "Doberman", Color: "Black", Value: 500})
 	a.Equal(success, false)
+	a.Equal(error, NewError(IDNotFound))
+}
+
+func (suite *StoreSuite) TestUpdateNegativeNumber() {
+	a := assert.New(suite.T())
+
+	success, error := suite.store.Update(0, Puppy{Breed: "Doberman", Color: "Black", Value: -500})
+	a.Equal(success, false)
+	a.Equal(error, NewError(NegativeValue))
 }
 
 func (suite *StoreSuite) TestDestroy() {
 	a := assert.New(suite.T())
-	success := suite.store.Destroy(1)
-	data := suite.store.Read(1)
 
+	success, error := suite.store.Destroy(1)
 	a.Equal(success, true)
+	a.Equal(error, nil)
+
+	data, error := suite.store.Read(1)
 	a.Equal(data, Puppy{})
+	a.Equal(error, NewError(IDNotFound))
 }
 
 func (suite *StoreSuite) TestDestroyNonExistent() {
 	a := assert.New(suite.T())
-	success := suite.store.Destroy(100)
 
+	success, error := suite.store.Destroy(100)
 	a.Equal(success, false)
+	a.Equal(error, NewError(IDNotFound))
 }
 
 func (suite *StoreSuite) TestIdIncrementOnDelete() {
 	a := assert.New(suite.T())
-	id := suite.store.Create(Puppy{Breed: "Greyhound", Color: "Light Brown", Value: "700"})
-	suite.store.Destroy(id)
-	newID := suite.store.Create(Puppy{Breed: "Greyhound", Color: "Light Brown", Value: "700"})
+	id, _ := suite.store.Create(Puppy{Breed: "Greyhound", Color: "Light Brown", Value: 700})
+	success, _ := suite.store.Destroy(id)
+	a.Equal(success, true)
 
+	newID, _ := suite.store.Create(Puppy{Breed: "Greyhound", Color: "Light Brown", Value: 700})
 	a.Equal(newID, 3)
 }
 

--- a/07_errors/patrickmarabeas/store_test.go
+++ b/07_errors/patrickmarabeas/store_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type StoreSuite struct {
+	suite.Suite
+	store Storer
+}
+
+func (suite *StoreSuite) TestCreate() {
+	a := assert.New(suite.T())
+	id := suite.store.Create(Puppy{Breed: "Wolf", Color: "Grey", Value: "450"})
+
+	a.Equal(id, 0)
+}
+
+func (suite *StoreSuite) TestCreateSecond() {
+	a := assert.New(suite.T())
+	id := suite.store.Create(Puppy{Breed: "Boxer", Color: "Brown", Value: "300"})
+
+	a.Equal(id, 1)
+}
+
+func (suite *StoreSuite) TestRead() {
+	a := assert.New(suite.T())
+	data := suite.store.Read(0)
+
+	a.Equal(data, Puppy{ID: 0, Breed: "Wolf", Color: "Grey", Value: "450"})
+}
+
+func (suite *StoreSuite) TestReadNonExistent() {
+	a := assert.New(suite.T())
+	success := suite.store.Read(100)
+
+	a.Equal(success, Puppy{})
+}
+
+func (suite *StoreSuite) TestUpdate() {
+	a := assert.New(suite.T())
+	success := suite.store.Update(0, Puppy{Breed: "Doberman", Color: "Black", Value: "500"})
+	data := suite.store.Read(0)
+
+	a.Equal(success, true)
+	a.Equal(data, Puppy{ID: 0, Breed: "Doberman", Color: "Black", Value: "500"})
+}
+
+func (suite *StoreSuite) TestUpdateNonExistent() {
+	a := assert.New(suite.T())
+	success := suite.store.Update(100, Puppy{Breed: "Doberman", Color: "Black", Value: "500"})
+
+	a.Equal(success, false)
+}
+
+func (suite *StoreSuite) TestDestroy() {
+	a := assert.New(suite.T())
+	success := suite.store.Destroy(1)
+	data := suite.store.Read(1)
+
+	a.Equal(success, true)
+	a.Equal(data, Puppy{})
+}
+
+func (suite *StoreSuite) TestDestroyNonExistent() {
+	a := assert.New(suite.T())
+	success := suite.store.Destroy(100)
+
+	a.Equal(success, false)
+}
+
+func (suite *StoreSuite) TestIdIncrementOnDelete() {
+	a := assert.New(suite.T())
+	id := suite.store.Create(Puppy{Breed: "Greyhound", Color: "Light Brown", Value: "700"})
+	suite.store.Destroy(id)
+	newID := suite.store.Create(Puppy{Breed: "Greyhound", Color: "Light Brown", Value: "700"})
+
+	a.Equal(newID, 3)
+}
+
+func TestStore(t *testing.T) {
+	suite.Run(t, &StoreSuite{store: NewMapStore()})
+	suite.Run(t, &StoreSuite{store: NewSyncStore()})
+}

--- a/07_errors/patrickmarabeas/syncStore.go
+++ b/07_errors/patrickmarabeas/syncStore.go
@@ -1,0 +1,50 @@
+package main
+
+// NewSyncStore returns a pointer to a new instance of the SyncStore struct which implements the Storer interface.
+func NewSyncStore() Storer {
+	return &SyncStore{
+		uuid: 0,
+	}
+}
+
+// Create increments the uuid and adds the provided Puppy struct to the store with this identifier.
+func (store *SyncStore) Create(puppy Puppy) int {
+	puppy.ID = store.uuid
+	store.Store(puppy.ID, puppy)
+	store.uuid++
+
+	return puppy.ID
+}
+
+// Read returns the puppy matching the provided uuid.
+// An empty Puppy struct is returned if the identifier does not exist.
+func (store *SyncStore) Read(id int) Puppy {
+	if value, ok := store.Load(id); ok {
+		return value.(Puppy)
+	}
+
+	return Puppy{}
+}
+
+// Update modifies the puppy matching the provided uuid in the store with the provided Puppy struct.
+// It returns a bool whether a matching identifier was modified or not.
+func (store *SyncStore) Update(id int, puppy Puppy) bool {
+	if _, ok := store.Load(id); !ok {
+		return false
+	}
+
+	puppy.ID = id
+	store.Store(id, puppy)
+	return true
+}
+
+// Destroy removes the puppy matching the provided uuid from the store.
+// It returns a bool whether a matching identifier was deleted or not.
+func (store *SyncStore) Destroy(id int) bool {
+	if _, ok := store.Load(id); !ok {
+		return false
+	}
+
+	store.Delete(id)
+	return true
+}

--- a/07_errors/patrickmarabeas/syncStore.go
+++ b/07_errors/patrickmarabeas/syncStore.go
@@ -13,9 +13,11 @@ func (store *SyncStore) Create(puppy Puppy) (int, error) {
 		return -1, NewError(NegativeValue)
 	}
 
+	store.Lock()
 	puppy.ID = store.uuid
 	store.Store(puppy.ID, puppy)
 	store.uuid++
+	store.Unlock()
 
 	return puppy.ID, nil
 }
@@ -23,9 +25,11 @@ func (store *SyncStore) Create(puppy Puppy) (int, error) {
 // Read returns the puppy matching the provided uuid.
 // An empty Puppy struct is returned if the identifier does not exist.
 func (store *SyncStore) Read(id int) (Puppy, error) {
+	store.RLock()
 	if value, ok := store.Load(id); ok {
 		return value.(Puppy), nil
 	}
+	store.RUnlock()
 
 	return Puppy{}, NewError(IDNotFound)
 }
@@ -42,6 +46,7 @@ func (store *SyncStore) Update(id int, puppy Puppy) (bool, error) {
 
 	puppy.ID = id
 	store.Store(id, puppy)
+
 	return true, nil
 }
 
@@ -52,6 +57,9 @@ func (store *SyncStore) Destroy(id int) (bool, error) {
 		return false, NewError(IDNotFound)
 	}
 
+	store.Lock()
 	store.Delete(id)
+	store.Unlock()
+
 	return true, nil
 }

--- a/07_errors/patrickmarabeas/syncStore.go
+++ b/07_errors/patrickmarabeas/syncStore.go
@@ -8,43 +8,50 @@ func NewSyncStore() Storer {
 }
 
 // Create increments the uuid and adds the provided Puppy struct to the store with this identifier.
-func (store *SyncStore) Create(puppy Puppy) int {
+func (store *SyncStore) Create(puppy Puppy) (int, error) {
+	if puppy.Value < 0 {
+		return -1, NewError(NegativeValue)
+	}
+
 	puppy.ID = store.uuid
 	store.Store(puppy.ID, puppy)
 	store.uuid++
 
-	return puppy.ID
+	return puppy.ID, nil
 }
 
 // Read returns the puppy matching the provided uuid.
 // An empty Puppy struct is returned if the identifier does not exist.
-func (store *SyncStore) Read(id int) Puppy {
+func (store *SyncStore) Read(id int) (Puppy, error) {
 	if value, ok := store.Load(id); ok {
-		return value.(Puppy)
+		return value.(Puppy), nil
 	}
 
-	return Puppy{}
+	return Puppy{}, NewError(IDNotFound)
 }
 
 // Update modifies the puppy matching the provided uuid in the store with the provided Puppy struct.
 // It returns a bool whether a matching identifier was modified or not.
-func (store *SyncStore) Update(id int, puppy Puppy) bool {
+func (store *SyncStore) Update(id int, puppy Puppy) (bool, error) {
 	if _, ok := store.Load(id); !ok {
-		return false
+		return false, NewError(IDNotFound)
+	}
+	if puppy.Value < 0 {
+		return false, NewError(NegativeValue)
 	}
 
 	puppy.ID = id
 	store.Store(id, puppy)
-	return true
+	return true, nil
 }
 
 // Destroy removes the puppy matching the provided uuid from the store.
 // It returns a bool whether a matching identifier was deleted or not.
-func (store *SyncStore) Destroy(id int) bool {
+func (store *SyncStore) Destroy(id int) (bool, error) {
 	if _, ok := store.Load(id); !ok {
-		return false
+		return false, NewError(IDNotFound)
 	}
 
 	store.Delete(id)
-	return true
+	return true, nil
 }

--- a/07_errors/patrickmarabeas/types.go
+++ b/07_errors/patrickmarabeas/types.go
@@ -1,21 +1,19 @@
 package main
 
-import (
-	"sync"
-)
+import "sync"
 
 type Puppy struct {
 	ID    int
 	Breed string
 	Color string
-	Value string
+	Value int // cents
 }
 
 type Storer interface {
-	Create(puppy Puppy) int
-	Read(ID int) Puppy
-	Update(ID int, puppy Puppy) bool
-	Destroy(ID int) bool
+	Create(puppy Puppy) (int, error)
+	Read(ID int) (Puppy, error)
+	Update(ID int, puppy Puppy) (bool, error)
+	Destroy(ID int) (bool, error)
 }
 
 type MapStore struct {

--- a/07_errors/patrickmarabeas/types.go
+++ b/07_errors/patrickmarabeas/types.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"sync"
+)
+
+type Puppy struct {
+	ID    int
+	Breed string
+	Color string
+	Value string
+}
+
+type Storer interface {
+	Create(puppy Puppy) int
+	Read(ID int) Puppy
+	Update(ID int, puppy Puppy) bool
+	Destroy(ID int) bool
+}
+
+type MapStore struct {
+	uuid  int
+	store map[int]Puppy
+}
+
+type SyncStore struct {
+	uuid int
+	sync.Map
+}

--- a/07_errors/patrickmarabeas/types.go
+++ b/07_errors/patrickmarabeas/types.go
@@ -24,4 +24,5 @@ type MapStore struct {
 type SyncStore struct {
 	uuid int
 	sync.Map
+	sync.RWMutex
 }


### PR DESCRIPTION
Implements custom error handling to the Storer interface. All methods must now return an error.

Errors that are covered:
- Puppy value < 0
- Puppy ID not found

Fixes / improvements also included:
- The value property in Puppy has had its type changed to an int to represent a numerical cent figure so that it may be properly throw an error if the value supplied is less than 0
- Proper locking in SyncMap

Fixes #589 
