### PR TITLE
Implement lab7 custom errors

### DIFF
--- a/07_errors/nickolee/error.go
+++ b/07_errors/nickolee/error.go
@@ -10,8 +10,7 @@ type Error struct {
 
 // Error() method lets us satisfy error interface for our custom error type
 func (e *Error) Error() string {
-	return fmt.Sprintf("Error code %d: %s",
-		e.Code, e.Message)
+	return fmt.Sprintf("PuppyStoreError %d: %s", e.Code, e.Message)
 }
 
 // Error codes

--- a/07_errors/nickolee/error.go
+++ b/07_errors/nickolee/error.go
@@ -1,0 +1,21 @@
+package puppystorer
+
+import "fmt"
+
+// Error (our custom error type) wraps errors with code, message and error itself - what does this even mean??
+type Error struct {
+	Message string
+	Code    int
+}
+
+// Error() method lets us satisfy error interface for our custom error type
+func (e *Error) Error() string {
+	return fmt.Sprintf("Error code %d: %s",
+		e.Code, e.Message)
+}
+
+// Error codes
+const (
+	ErrNegativePuppyID = 400
+	ErrPuppyNotFound   = 404
+)

--- a/07_errors/nickolee/error_test.go
+++ b/07_errors/nickolee/error_test.go
@@ -1,0 +1,17 @@
+package puppystorer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestError(t *testing.T) {
+	err := Error{
+		Message: "Dalmations",
+		Code:    101,
+	}
+
+	errMsg := err.Error()
+	assert.Equal(t, "PuppyStoreError 101: Dalmations", errMsg)
+}

--- a/07_errors/nickolee/mapstore.go
+++ b/07_errors/nickolee/mapstore.go
@@ -1,0 +1,78 @@
+package puppystorer
+
+import "fmt"
+
+// NewSyncStore() conveniently creates a new initialised syncstore
+func NewMapStore() *MapStore {
+	return &MapStore{store: make(map[int]Puppy), nextID: 0}
+}
+
+// MapStore will serve as our in-memory DB
+type MapStore struct {
+	store  map[int]Puppy
+	nextID int
+}
+
+// IncrementCounter increases the ID counter everytime a new Puppy is created to prevent overwrite issues
+// in DeletePuppy()
+func (ms *MapStore) incrementCounter() {
+	ms.nextID++
+}
+
+// CreatePuppy lets you create a new unique puppy in MapStore
+func (ms *MapStore) CreatePuppy(puppy *Puppy) (int, error) {
+	// Check for negative value. If negative return custom error type
+	if puppy.Value < 0 {
+		return 0, &Error{
+			Message: "Sorry puppy value cannot be negative. The dog has to be worth something :)",
+			Code:    ErrNegativePuppyID,
+		}
+	}
+
+	// Else create new puppy (happy path)
+	ms.incrementCounter()
+	puppy.ID = ms.nextID
+	ms.store[puppy.ID] = *puppy // store the puppy object at this key in the map store (like a row in a table)
+	return puppy.ID, nil        // return u a handle to the correct row in the table that is MapStore
+}
+
+// ReadPuppy lets you GET a puppy from MapStore if it exists. Else it will return an error
+func (ms *MapStore) ReadPuppy(id int) (*Puppy, error) {
+	// if the key exists, then puppy is assigned the value stored under the key
+	// referred to: https://blog.golang.org/go-maps-in-action
+	if puppy, ok := ms.store[id]; ok {
+		return &puppy, nil
+	}
+
+	// else return nil pointer to puppy and one of our custom errors
+	return nil, &Error{
+		Message: fmt.Sprintf("Sorry puppy with ID %d does not exist", id),
+		Code:    ErrPuppyNotFound,
+	}
+}
+
+// UpdatePuppy lets you update a "row" in MapStore
+func (ms *MapStore) UpdatePuppy(id int, puppy *Puppy) error {
+	if _, ok := ms.store[id]; !ok {
+		return &Error{
+			Message: fmt.Sprintf("Sorry puppy with ID %d does not exist", id),
+			Code:    ErrPuppyNotFound,
+		}
+	}
+
+	puppy.ID = id // ignore id in puppy struct and use id passed as argument as id is created in storer
+	ms.store[id] = *puppy
+	return nil
+}
+
+// DeletePuppy lets you delete a specific puppy in MapStore
+func (ms *MapStore) DeletePuppy(id int) error {
+	if _, ok := ms.store[id]; !ok {
+		return &Error{
+			Message: fmt.Sprintf("Sorry puppy with ID %d does not exist", id),
+			Code:    ErrPuppyNotFound,
+		}
+	}
+	delete(ms.store, id)
+	return nil
+}

--- a/07_errors/nickolee/mapstore_test.go
+++ b/07_errors/nickolee/mapstore_test.go
@@ -1,0 +1,30 @@
+package puppystorer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Writing one test to give confidence that mapstore is creating and retrieving puppies correctly
+func TestCreateAndRetrievePuppyMapStore(t *testing.T) {
+	assert := assert.New(t)
+	ms := MapStore{store: make(map[int]Puppy), nextID: 0}
+
+	tests := []*Puppy{
+		{Breed: "Snoopy", Colour: "Is sleepy", Value: 2300.90},
+		{Breed: "Arcanine", Colour: "Level 100", Value: 9300.90},
+		{Breed: "The Hound", Colour: "Of Baskerville", Value: 12300.90},
+		{Breed: "Laika", Colour: "First dog on moon", Value: 22300.90},
+		{Breed: "Simba", Colour: "Pumba", Value: 92300.90},
+	}
+
+	for i, testPuppy := range tests {
+		createdPuppy, err := ms.CreatePuppy(testPuppy)
+		assert.NoError(err)
+		assert.Equal(i+1, createdPuppy) // test that nextID is working properly
+		retrievedPuppy, err := ms.ReadPuppy(createdPuppy)
+		assert.NoError(err)
+		assert.Equalf(testPuppy, retrievedPuppy, "Testcase TestCreateAndRetrievePuppySyncStore failed")
+	}
+}

--- a/07_errors/nickolee/storer_test.go
+++ b/07_errors/nickolee/storer_test.go
@@ -1,0 +1,76 @@
+package puppystorer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type StorerSuite struct {
+	suite.Suite
+	store Storer
+}
+
+// A bunch of seed puppies
+var puppies = []*Puppy{
+	{Breed: "Laika", Colour: "First dog on moon", Value: 2130.50},
+	{Breed: "Pomsky", Colour: "Violet", Value: 777.77},
+	{Breed: "Dalmatian", Colour: "Cruella de vil", Value: 101},
+	{Breed: "Rare Lvl 100 Arcanine", Colour: "Brown", Value: 9999.99},
+	{Breed: "Cheap Pug", Colour: "Cheap Brown", Value: -500.50},
+}
+
+func (suite *StorerSuite) TestCreateAndRetrievePuppy() {
+	puppyID, err := suite.store.CreatePuppy(puppies[3])
+	suite.Nil(err)
+	puppy, err := suite.store.ReadPuppy(puppyID)
+	suite.Nil(err)
+	suite.Equal(puppy, puppies[3])
+
+	// Test negative value puppy
+	_, err = suite.store.CreatePuppy(puppies[4])
+	suite.Equal("Error code 400: Sorry puppy value cannot be negative. The dog has to be worth something :)",
+		err.Error())
+}
+
+func (suite *StorerSuite) TestUpdatePuppy() {
+	// test happy path
+	id, err := suite.store.CreatePuppy(puppies[0])
+	suite.Nil(err)
+	err = suite.store.UpdatePuppy(id, puppies[3])
+	suite.Nil(err) // if no error it means puppy was updated successfully
+	// retrieve to double check update was correct in the following assertion on next line
+	retrievedPuppy, err := suite.store.ReadPuppy(id)
+	suite.Nil(err)
+	suite.Equal(puppies[3], retrievedPuppy)
+
+	// test error path
+	err = suite.store.UpdatePuppy(1829246, puppies[1]) // give non-existent id
+	suite.Equal("Error code 404: Sorry puppy with ID 1829246 does not exist", err.Error())
+}
+
+func (suite *StorerSuite) TestDeletePuppy() {
+	// Test happy path
+	id, err := suite.store.CreatePuppy(puppies[1])
+	suite.NoError(err)
+	err = suite.store.DeletePuppy(id)
+	suite.NoError(err) // if nil means successfully deleted
+	// verify delete was successful by trying to retrieve puppy
+	retrievedPuppy, err := suite.store.ReadPuppy(id)
+	suite.Nil(retrievedPuppy) // should get back a nil pointer since there ain't no more puppy
+	suite.Error(err)          // asserting there should be an error since you cannot retrieve a deleted puppy
+
+	// Test error path
+	err = suite.store.DeletePuppy(1829246)
+	suite.Equal("Error code 404: Sorry puppy with ID 1829246 does not exist", err.Error())
+}
+
+// Run tests for Storer using MapStore implementation of Storer interface
+func TestMapStore(t *testing.T) {
+	suite.Run(t, &StorerSuite{store: NewMapStore()})
+}
+
+// Run tests for Storer using SyncStore implementation of Storer interface
+func TestSyncStore(t *testing.T) {
+	suite.Run(t, &StorerSuite{store: NewSyncStore()})
+}

--- a/07_errors/nickolee/storer_test.go
+++ b/07_errors/nickolee/storer_test.go
@@ -1,7 +1,6 @@
 package puppystorer
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -35,9 +34,6 @@ func (suite *StorerSuite) TestCreateAndRetrievePuppy() {
 	actualErr, _ := rawErr.(*Error) // Type cast, err now holds the actual error
 	suite.Equal(ErrNegativePuppyID, actualErr.Code)
 	suite.Equal("Sorry puppy value cannot be negative. The dog has to be worth something :)", actualErr.Message)
-
-	// test Error() method in error.go for 100% coverage
-	suite.Equal(actualErr.Error(), fmt.Sprintf("PuppyStoreError %d: %s", actualErr.Code, actualErr.Message))
 }
 
 func (suite *StorerSuite) TestUpdatePuppy() {

--- a/07_errors/nickolee/syncstore.go
+++ b/07_errors/nickolee/syncstore.go
@@ -1,0 +1,94 @@
+package puppystorer
+
+import (
+	"fmt"
+	"sync"
+)
+
+// NewSyncStore() conveniently creates a new initialised syncstore
+func NewSyncStore() *SyncStore {
+	return &SyncStore{Map: sync.Map{}}
+}
+
+// SyncStore struct. To serve as alternative in-memory DB. It also implements Storer interface
+type SyncStore struct {
+	sync.Map
+	nextID int
+	sync.Mutex
+}
+
+// IncrementCounter increases the ID counter everytime a new Puppy is created to prevent overwrite issues
+// in DeletePuppy()
+func (m *SyncStore) incrementCounter() {
+	m.nextID++
+}
+
+// CreatePuppy creates a puppy in sync store. Note we use a pointer receiver for this
+func (m *SyncStore) CreatePuppy(puppy *Puppy) (int, error) {
+	// Check for negative value. If negative return custom error type
+	if puppy.Value < 0 {
+		return 0, &Error{
+			Message: "Sorry puppy value cannot be negative. The dog has to be worth something :)",
+			Code:    ErrNegativePuppyID,
+		}
+	}
+
+	// Add locking for thread safety before a write operation occurs
+	m.Lock()
+	defer m.Unlock()
+
+	// Else create new puppy (happy path)
+	m.incrementCounter()
+	puppy.ID = m.nextID
+	m.Store(puppy.ID, *puppy)
+	return puppy.ID, nil
+}
+
+// ReadPuppy retrieves puppy from sync store
+func (m *SyncStore) ReadPuppy(id int) (*Puppy, error) {
+	if puppyData, exists := m.Load(id); exists {
+		// This is not to do with calling method or accessing field, it's saying "cast to puppy"
+		puppy := puppyData.(Puppy)
+		return &puppy, nil
+	}
+
+	// else return nil pointer to puppy and one of our custom errors
+	return nil, &Error{
+		Message: fmt.Sprintf("Sorry puppy with ID %d does not exist", id),
+		Code:    ErrPuppyNotFound,
+	}
+}
+
+// UpdatePuppy updates a puppy in sync store
+func (m *SyncStore) UpdatePuppy(id int, puppy *Puppy) error {
+	// Add locking for thread safety before a write operation occurs
+	m.Lock()
+	defer m.Unlock()
+
+	if _, exists := m.Load(id); !exists {
+		return &Error{
+			Message: fmt.Sprintf("Sorry puppy with ID %d does not exist", id),
+			Code:    ErrPuppyNotFound,
+		}
+	}
+
+	puppy.ID = id // ignore id in puppy struct and use id passed as argument as id is created in storer
+	m.Store(id, *puppy)
+	return nil
+}
+
+// DeletePuppy deletes a puppy in sync store
+func (m *SyncStore) DeletePuppy(id int) error {
+	// Add locking for thread safety before a write operation occurs
+	m.Lock()
+	defer m.Unlock()
+
+	if _, exists := m.Load(id); !exists {
+		return &Error{
+			Message: fmt.Sprintf("Sorry puppy with ID %d does not exist", id),
+			Code:    ErrPuppyNotFound,
+		}
+	}
+	m.Delete(id)
+	return nil
+}

--- a/07_errors/nickolee/syncstore_test.go
+++ b/07_errors/nickolee/syncstore_test.go
@@ -1,0 +1,31 @@
+package puppystorer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+/// Writing one test to give confidence that mapstore is retrieving puppies correctly
+func TestCreateAndRetrievePuppySyncStore(t *testing.T) {
+	assert := assert.New(t)
+	ss := SyncStore{}
+
+	tests := []*Puppy{
+		{Breed: "Snoopy", Colour: "Is sleepy", Value: 2300.90},
+		{Breed: "Arcanine", Colour: "Level 100", Value: 9300.90},
+		{Breed: "The Hound", Colour: "Of Baskerville", Value: 12300.90},
+		{Breed: "Laika", Colour: "First dog on moon", Value: 22300.90},
+		{Breed: "Simba", Colour: "Pumba", Value: 92300.90},
+		{Breed: "Direwolf", Colour: "Isn't technically a wolf", Value: 22300.90},
+	}
+
+	for i, testPuppy := range tests {
+		createdPuppy, err := ss.CreatePuppy(testPuppy)
+		assert.NoError(err)
+		assert.Equal(i+1, createdPuppy) // test that nextID is working properly
+		retrievedPuppy, err := ss.ReadPuppy(testPuppy.ID)
+		assert.NoError(err)
+		assert.Equalf(testPuppy, retrievedPuppy, "Testcase TestCreateAndRetrievePuppySyncStore failed")
+	}
+}

--- a/07_errors/nickolee/types.go
+++ b/07_errors/nickolee/types.go
@@ -1,0 +1,17 @@
+package puppystorer
+
+// Puppy data structure stores puppy properties
+type Puppy struct {
+	ID     int
+	Breed  string
+	Colour string
+	Value  float64
+}
+
+// Storer defines standard CRUD operations for Pets
+type Storer interface {
+	CreatePuppy(puppy *Puppy) (int, error) // takes a pointer which makes sense since you are modifying that object
+	ReadPuppy(id int) (*Puppy, error)
+	UpdatePuppy(id int, puppy *Puppy) error
+	DeletePuppy(id int) error
+}


### PR DESCRIPTION
Build upon lab6 + add custom errors + add thread safety in sync.map
+ write tests

Fixes #614 

Review of colleague's PR #573 

#### Changes proposed in this PR:

Implement lab7 custom errors 
Build upon lab6 + add custom errors + add thread safety in sync.map + write tests
