### PR TITLE
Update golangci-lint version and disable funlen

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,8 @@
 service:
-  golangci-lint-version: 1.17.1
+  golangci-lint-version: 1.18.0
 linters:
   enable-all: true
   disable:
     - gochecknoglobals
     - dupl
+    - funlen

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: go
 env:
   - GO111MODULE=on
 go:
-  - "1.12.x"
+  - "1.13.x"
 before_script:
-  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -x -- -b $(go env GOPATH)/bin v1.17.1
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -x -- -b $(go env GOPATH)/bin v1.18.0
 script:
   - golangci-lint run
   - go test -v -race -coverprofile=coverage.out -covermode=atomic ./...


### PR DESCRIPTION
Currently, CI is failing due to a linting error caused by go version and golangci-lint version mismatch. Therefore, bumping go version to 1.13 and golanci-lint version to 1.18.0

Fixes #672